### PR TITLE
Re-render screen after clicking on example box in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ screen.append(box);
 
 box.on('click', function(data) {
   box.setContent('{center}Some different {red-fg}content{/red-fg}.{/center}');
+  screen.render();
 });
 
 screen.on('keypress', function(ch, key) {


### PR DESCRIPTION
It seems like this is necessary for your example to work.
Is there a way to re-render a portion of the screen instead of the entire thing?
