### PR TITLE
fixes bug where exception raise if parent is not available

### DIFF
--- a/lib/widget.js
+++ b/lib/widget.js
@@ -2520,7 +2520,7 @@ Element.prototype._getTop = function(get) {
     }
   }
 
-  return (parent.top || 0) + top;
+  return ((parent && parent.top) || 0) + top;
 };
 
 Element.prototype.__defineGetter__('top', function() {


### PR DESCRIPTION
I found that when using the example of a scrollable list from http://blog.nodejitsu.com/a-blessed-ui-for-jitsu, I would get an exception during list.setItems() if the list was not already added to the screen - I wanted to create the lists and add and remove them to the screen in response to user input.

This gist reproduces the problem: https://gist.github.com/johnspackman/6192788

The fix is in the commit.
