### PR TITLE
fixes bug where keyboard events are broken if repeatedly adding & removi...

### DIFF
--- a/lib/widget.js
+++ b/lib/widget.js
@@ -115,11 +115,6 @@ Node.prototype.remove = function(element) {
 
   this.children.splice(i, 1);
 
-  i = this.screen.clickable.indexOf(element);
-  if (~i) this.screen.clickable.splice(i, 1);
-  i = this.screen.keyable.indexOf(element);
-  if (~i) this.screen.keyable.splice(i, 1);
-
   element.emit('reparent', null);
   this.emit('remove', element);
 


### PR DESCRIPTION
...ng widgets

When the widget is removed from the screen, Node.remove() removes the
widget from screen.clickable and screen.keyable but Node.insert()
doesn't restore clickable & keyable (normally done by
Screen._listenKeys via the constructor).
