### PR TITLE
Make Element.focus() set the focus

### DIFF
--- a/lib/widget.js
+++ b/lib/widget.js
@@ -1941,6 +1941,7 @@ Element.prototype.toggle = function() {
 };
 
 Element.prototype.focus = function() {
+  this.screen._focus(this, this.screen.focused);
   return this.screen.focused = this;
 };
 


### PR DESCRIPTION
Element.focus() didn't set focus but appears to be used pretty
consistently by the rest of the code as though to set the focus.  This patch
makes that happen
