### PR TITLE
Allow Textarea to exit editing and focus when tab is pressed if inputOnFocus is set

### DIFF
--- a/lib/widget.js
+++ b/lib/widget.js
@@ -4559,6 +4559,9 @@ Textarea.prototype._listener = function(ch, key) {
   // to the screen and screen buffer here.
   if (key.name === 'escape') {
     done(null, null);
+  } else if (this.options.inputOnFocus && key.name === 'tab') {
+    done(null, null);
+    this.screen.focusNext();
   } else if (key.name === 'backspace') {
     if (this.value.length) {
       this.value = this.value.slice(0, -1);


### PR DESCRIPTION
Although Textarea can automatically start editing when the focus reaches it, there isn't a natural way for the user to leave the text area - having to press escape to exit editing is strange for users, especially as they probably arrived at the field by pressing tab.  This PR allows tab to stop editing the field and for focus to switch.

This includes https://github.com/chjj/blessed/pull/10
