### PR TITLE
Fix for return to select on list

### DIFF
--- a/lib/widget.js
+++ b/lib/widget.js
@@ -3963,7 +3963,7 @@ function List(options) {
         self.screen.render();
         return;
       }
-      if (key.name === 'enter'
+      if (key.name === 'enter' || key.name === 'return'
           || (options.vi && key.name === 'l' && !key.shift)) {
         self.emit('action', self.items[self.selected], self.selected);
         self.emit('select', self.items[self.selected], self.selected);


### PR DESCRIPTION
Bug: When you hit return on a mac, list items don't select
