### PR TITLE
add var self = this to progress bar

### DIFF
--- a/lib/widget.js
+++ b/lib/widget.js
@@ -4832,6 +4832,8 @@ Button.prototype.press = function() {
  */
 
 function ProgressBar(options) {
+  var self = this;
+
   if (!(this instanceof Node)) {
     return new ProgressBar(options);
   }


### PR DESCRIPTION
Fixes crash when using progress bar:
    ReferenceError: self is not defined
    at ProgressBar.<anonymous>
    (/home/cbryant/bl/node_modules/blessed/lib/widget.js:4862:11)
    ...
