### PR TITLE
fix setIndex to include last item

### DIFF
--- a/lib/widget.js
+++ b/lib/widget.js
@@ -2307,11 +2307,8 @@ Element.prototype.setIndex = function(index) {
   var i = this.parent.children.indexOf(this);
   if (!~i) return;
 
-  this.parent.children.splice(index, 0, this);
-
-  if (index <= i) i++;
-
-  this.parent.children.splice(i, 1);
+  var item = this.parent.children.splice(i, 1)[0]
+  this.parent.children.splice(index, 0, item);
 };
 
 Element.prototype.setFront = function() {


### PR DESCRIPTION
I am using blessed to reorder windows on the screen. When I bring a window to the front, it always becomes the second-most front window, behind the last window added to the system.

This change fixes that behavior.
