### PR TITLE
New `Tput` instances don't `setup()` when not passed `options.term`

### DIFF
--- a/lib/tput.js
+++ b/lib/tput.js
@@ -55,7 +55,7 @@ function Tput(options) {
   this.terminfoFile = options.terminfoFile;
   this.termcapFile = options.termcapFile;
 
-  if (options.term || options.terminal) {
+  if (this.terminal) {
     this.setup();
   }
 };


### PR DESCRIPTION
The first `cursor_left()` call below works, but the second doesn't:

```
var Tput = new require('blessed').Tput
  , tput1 = new Tput({term: process.env.TERM})
  , tput2 = new Tput()

tput1.cursor_left()
tput2.cursor_left()
```

The error:

```
/Users/ELLIOTTCABLE/Dropbox/Code/Paws/Paws.js/tput_test.js:6
tput2.cursor_left()
      ^
TypeError: Object #<Tput> has no method 'cursor_left'
    at Object.<anonymous> (/Users/ELLIOTTCABLE/Dropbox/Code/Paws/Paws.js/tput_test.js:6:7)
```

I've fixed this, but I'm not sure if it's in the way you'd like to see it fixed (I'm not clear on why the `setup()` call is guarded in the first place.) You shouldn't pull this yet; let me know if you'd rather I remove the guard entirely, or, if there's a reason for its existence that I'm not aware of, I can simply add `env.TERM` existence to the previous guard.
