### PR TITLE
fixed issue with focus handling in forms

### DIFF
--- a/lib/widget.js
+++ b/lib/widget.js
@@ -4472,6 +4472,7 @@ Form.prototype.next = function() {
   }
 
   this._selected = this._children[i + 1];
+  if (!this.visible) return undefined;
   if (!this._selected.visible) return this.next();
   return this._selected;
 };
@@ -4496,6 +4497,7 @@ Form.prototype.previous = function() {
   }
 
   this._selected = this._children[i - 1];
+  if (!this.visible) return undefined;
   if (!this._selected.visible) return this.previous();
   return this._selected;
 };


### PR DESCRIPTION
Ich you create a form append and then remove it from the screen you get
an RangeError because next() calls itself infinitely

This is a problem since the event handlers in the form don't get removed if it is detached from a screen.
 In my fix I simply check for the visibility of the parent form 
