### PR TITLE
Refactors, new features, etc.

### DIFF
--- a/example/ping
+++ b/example/ping
@@ -23,7 +23,7 @@ if (/^(-h|--help|-\?)$/.test(process.argv[2])) {
   return process.exit(0);
 }
 
-var blessed = require('blessed')
+var blessed = require('../')
   , nssocket;
 
 try {

--- a/example/simple-form.js
+++ b/example/simple-form.js
@@ -1,4 +1,4 @@
-var blessed = require('blessed')
+var blessed = require('../')
   , screen = blessed.screen();
 
 var form = blessed.form({

--- a/example/time.js
+++ b/example/time.js
@@ -18,7 +18,7 @@ if (~argv.indexOf('-h') || ~argv.indexOf('--help')) {
   return process.exit(0);
 }
 
-var blessed = require('blessed');
+var blessed = require('../');
 
 var screen = blessed.screen({
   autoPadding: true

--- a/example/widget.js
+++ b/example/widget.js
@@ -12,7 +12,7 @@ var box = blessed.box({
   content: 'Hello {bold}world{/bold}!',
   tags: true,
   border: {
-    type: 'line'
+    type: 'round'
   },
   style: {
     fg: 'white',

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -1495,7 +1495,7 @@ Screen.prototype.focusOffset = function(offset) {
   return this.keyable[i].focus();
 };
 
-Screen.prototype.focusPrev =
+Screen.prototype.focusPrev = function() { return this.focusPrevious(); };
 Screen.prototype.focusPrevious = function() {
   return this.focusOffset(-1);
 };
@@ -1623,7 +1623,7 @@ Screen.prototype.onceKey = function() {
   return this.program.onceKey.apply(this, arguments);
 };
 
-Screen.prototype.unkey =
+Screen.prototype.unkey = function() { return this.removeKey(); };
 Screen.prototype.removeKey = function() {
   return this.program.unkey.apply(this, arguments);
 };
@@ -2370,7 +2370,7 @@ Element.prototype.onceKey = function() {
   return this.screen.program.onceKey.apply(this, arguments);
 };
 
-Element.prototype.unkey =
+Element.prototype.unkey = function() { return this.removeKey(); };
 Element.prototype.removeKey = function() {
   return this.screen.program.unkey.apply(this, arguments);
 };
@@ -3880,7 +3880,7 @@ ScrollableBox.prototype._scrollBottom = function() {
   return bottom;
 };
 
-ScrollableBox.prototype.setScroll =
+ScrollableBox.prototype.setScroll = function(offset) { return this.scrollTo(offset); };
 ScrollableBox.prototype.scrollTo = function(offset) {
   return this.scroll(offset - (this.childBase + this.childOffset));
 };
@@ -4271,8 +4271,8 @@ List.prototype._calcNextTop = function() {
   return top;
 };
 
-List.prototype.add =
-List.prototype.addItem =
+List.prototype.add = function(item) { return this.appendItem(item); };
+List.prototype.addItem = function(item) { return this.appendItem(item); };
 List.prototype.appendItem = function(item) {
   var self = this;
 
@@ -4886,8 +4886,8 @@ Textarea.prototype._updateCursor = function(get) {
   }
 };
 
-Textarea.prototype.input =
-Textarea.prototype.setInput =
+Textarea.prototype.input = function() { return this.readInput(); };
+Textarea.prototype.setInput = function() { return this.readInput(); };
 Textarea.prototype.readInput = function(callback) {
   var self = this
     , focused = this.screen.focused === this;
@@ -5027,7 +5027,7 @@ Textarea.prototype.setValue = function(value) {
   }
 };
 
-Textarea.prototype.clearInput =
+Textarea.prototype.clearInput = function() { return this.clearInput(); };
 Textarea.prototype.clearValue = function() {
   return this.setValue('');
 };
@@ -5047,8 +5047,8 @@ Textarea.prototype.render = function() {
   return this._render();
 };
 
-Textarea.prototype.editor =
-Textarea.prototype.setEditor =
+Textarea.prototype.editor = function(callback) { return this.readEditor(callback); };
+Textarea.prototype.setEditor = function(callback) { return this.readEditor(callback); };
 Textarea.prototype.readEditor = function(callback) {
   var self = this;
 
@@ -5863,7 +5863,7 @@ Message.prototype.__proto__ = Box.prototype;
 
 Message.prototype.type = 'message';
 
-Message.prototype.log =
+Message.prototype.log = function(text, time, callback) { return this.display(text, time, callback); };
 Message.prototype.display = function(text, time, callback) {
   var self = this;
   if (typeof time === 'function') {
@@ -6159,8 +6159,8 @@ Listbar.prototype.setItems = function(commands) {
   });
 };
 
-Listbar.prototype.add =
-Listbar.prototype.addItem =
+Listbar.prototype.add = function(item, callback) { return this.appendItem(item, callback); };
+Listbar.prototype.addItem = function(item, callback) { return this.appendItem(item, callback); };
 Listbar.prototype.appendItem = function(item, callback) {
   var self = this
     , prev = this.items[this.items.length - 1]

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -4217,6 +4217,14 @@ List.prototype.__proto__ = Box.prototype;
 
 List.prototype.type = 'list';
 
+List.prototype._calcNextTop = function() {
+  var top = this.itop;
+  this.items.forEach(function(node) {
+    top += node.height;
+  });
+  return top;
+};
+
 List.prototype.add =
 List.prototype.addItem =
 List.prototype.appendItem = function(item) {
@@ -4229,7 +4237,7 @@ List.prototype.appendItem = function(item) {
     screen: this.screen,
     content: item,
     align: this.align || 'left',
-    top: this.itop + this.items.length,
+    top: this._calcNextTop(),
     left: this.ileft + 1,
     right: this.iright + 1,
     tags: this.parseTags,
@@ -4257,22 +4265,24 @@ List.prototype.appendItem = function(item) {
   });
 
   var item = new Box(options);
+};
 
-  this.items.push(item);
-  this.append(item);
+List.prototype.appendNode = function(node) {
+  this.items.push(node);
+  this.append(node);
 
   if (this.items.length === 1) {
     this.select(0);
   }
 
   if (this.mouse) {
-    item.on('click', function(data) {
-      if (self.items[self.selected] === item) {
-        self.emit('action', item, self.selected);
-        self.emit('select', item, self.selected);
+    node.on('click', function(data) {
+      if (self.items[self.selected] === node) {
+        self.emit('action', node, self.selected);
+        self.emit('select', node, self.selected);
         return;
       }
-      self.select(item);
+      self.select(node);
       self.screen.render();
     });
   }
@@ -4302,6 +4312,10 @@ List.prototype.getItemIndex = function(child) {
 
 List.prototype.getItem = function(child) {
   return this.items[this.getItemIndex(child)];
+};
+
+List.prototype.getItems = function(child) {
+  return this.ritems;
 };
 
 List.prototype.removeItem = function(child) {
@@ -4375,6 +4389,7 @@ List.prototype.select = function(index) {
   this.selected = index;
   this.value = this.ritems[this.selected];
   this.scrollTo(this.selected);
+  this.emit('change', this.items[this.selected], this.selected);
 };
 
 List.prototype.move = function(offset) {

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -19,6 +19,124 @@ var colors = require('./colors')
   , widget = exports;
 
 /**
+ * Utility
+ */
+
+var Styles = ['bg', 'fg', 'bold', 'underline',
+   'blink', 'inverse', 'invisible'];
+
+var strip = function(text) {
+  return text.replace(/\x1b\[[\d;]*m/g, '');
+};
+
+var convert = function(text, _program) {
+  _program = _program || program.global;
+
+  var out = ''
+    , state
+    , bg = []
+    , fg = []
+    , flag = []
+    , cap
+    , slash
+    , param
+    , attr
+    , esc;
+
+  for (;;) {
+    if (!esc && (cap = /^{escape}/.exec(text))) {
+      text = text.substring(cap[0].length);
+      esc = true;
+      continue;
+    }
+
+    if (esc && (cap = /^([\s\S]+?){\/escape}/.exec(text))) {
+      text = text.substring(cap[0].length);
+      out += cap[1];
+      esc = false;
+      continue;
+    }
+
+    if (esc) {
+      // throw new Error('Unterminated escape tag.');
+      out += text;
+      break;
+    }
+
+    if (cap = /^{(\/?)([\w\-,;!#]*)}/.exec(text)) {
+      text = text.substring(cap[0].length);
+      slash = cap[1] === '/';
+      param = cap[2].replace(/-/g, ' ');
+
+      if (param === 'open') {
+        out += '{';
+        continue;
+      } else if (param === 'close') {
+        out += '}';
+        continue;
+      }
+
+      if (param.slice(-3) === ' bg') state = bg;
+      else if (param.slice(-3) === ' fg') state = fg;
+      else state = flag;
+
+      if (slash) {
+        if (!param) {
+          out += _program._attr('normal');
+          bg.length = 0;
+          fg.length = 0;
+          flag.length = 0;
+        } else {
+          attr = _program._attr(param, false);
+          if (attr == null) {
+            out += cap[0];
+          } else {
+            // if (param !== state[state.length-1]) {
+            //   throw new Error('Misnested tags.');
+            // }
+            state.pop();
+            if (state.length) {
+              out += _program._attr(state[state.length-1]);
+            } else {
+              out += attr;
+            }
+          }
+        }
+      } else {
+        if (!param) {
+          out += cap[0];
+        } else {
+          attr = _program._attr(param);
+          if (attr == null) {
+            out += cap[0];
+          } else {
+            state.push(param);
+            out += attr;
+          }
+        }
+      }
+
+      continue;
+    }
+
+    if (cap = /^[\s\S]+?(?={\/?[\w\-,;!#]*})/.exec(text)) {
+      text = text.substring(cap[0].length);
+      out += cap[0];
+      continue;
+    }
+
+    out += text;
+    break;
+  }
+
+  return out;
+};
+
+var toText = function(text) {
+  return strip(convert(text));
+}
+
+/**
  * Node
  */
 
@@ -1890,6 +2008,8 @@ Element.prototype.sattr = function(obj, fg, bg) {
     , blink = obj.blink
     , inverse = obj.inverse
     , invisible = obj.invisible;
+  fg = fg || obj.fg;
+  bg = bg || obj.bg;
 
   // This used to be a loop, but I decided
   // to unroll it for performance's sake.
@@ -1960,12 +2080,12 @@ Element.prototype.getContent = function() {
 
 Element.prototype.setText = function(content, noClear) {
   content = content || '';
-  content = content.replace(/\x1b\[[\d;]*m/g, '');
+  content = strip(content);
   return this.setContent(content, noClear, true);
 };
 
 Element.prototype.getText = function() {
-  return this.getContent().replace(/\x1b\[[\d;]*m/g, '');
+  return strip(this.getContent());
 };
 
 Element.prototype.parseContent = function(noTags) {
@@ -2012,112 +2132,32 @@ Element.prototype.parseContent = function(noTags) {
 
 // Convert `{red-fg}foo{/red-fg}` to `\x1b[31mfoo\x1b[39m`.
 Element.prototype._parseTags = function(text) {
+  var rpad = /^(.*){rpad(|:.*?)}(.*)$/.exec(text);
+  if ( rpad ) {
+    var pad = rpad[2] || ' ';
+    var left = this._parseTags(rpad[1])
+    var right = this._parseTags(rpad[3]);
+
+    var leftlen = strip(left).length;
+    var rightlen = strip(right).length;
+    var count = this.width - leftlen - rightlen - 1;
+
+    var result = '';
+    while ( count > 0 ) {
+      result += pad;
+      --count;
+    }
+    return left + result + right;
+  }
+
   if (!this.parseTags) return text;
   if (!/{\/?[\w\-,;!#]*}/.test(text)) return text;
 
-  var program = this.screen.program
-    , out = ''
-    , state
-    , bg = []
-    , fg = []
-    , flag = []
-    , cap
-    , slash
-    , param
-    , attr
-    , esc;
-
-  for (;;) {
-    if (!esc && (cap = /^{escape}/.exec(text))) {
-      text = text.substring(cap[0].length);
-      esc = true;
-      continue;
-    }
-
-    if (esc && (cap = /^([\s\S]+?){\/escape}/.exec(text))) {
-      text = text.substring(cap[0].length);
-      out += cap[1];
-      esc = false;
-      continue;
-    }
-
-    if (esc) {
-      // throw new Error('Unterminated escape tag.');
-      out += text;
-      break;
-    }
-
-    if (cap = /^{(\/?)([\w\-,;!#]*)}/.exec(text)) {
-      text = text.substring(cap[0].length);
-      slash = cap[1] === '/';
-      param = cap[2].replace(/-/g, ' ');
-
-      if (param === 'open') {
-        out += '{';
-        continue;
-      } else if (param === 'close') {
-        out += '}';
-        continue;
-      }
-
-      if (param.slice(-3) === ' bg') state = bg;
-      else if (param.slice(-3) === ' fg') state = fg;
-      else state = flag;
-
-      if (slash) {
-        if (!param) {
-          out += program._attr('normal');
-          bg.length = 0;
-          fg.length = 0;
-          flag.length = 0;
-        } else {
-          attr = program._attr(param, false);
-          if (attr == null) {
-            out += cap[0];
-          } else {
-            // if (param !== state[state.length-1]) {
-            //   throw new Error('Misnested tags.');
-            // }
-            state.pop();
-            if (state.length) {
-              out += program._attr(state[state.length-1]);
-            } else {
-              out += attr;
-            }
-          }
-        }
-      } else {
-        if (!param) {
-          out += cap[0];
-        } else {
-          attr = program._attr(param);
-          if (attr == null) {
-            out += cap[0];
-          } else {
-            state.push(param);
-            out += attr;
-          }
-        }
-      }
-
-      continue;
-    }
-
-    if (cap = /^[\s\S]+?(?={\/?[\w\-,;!#]*})/.exec(text)) {
-      text = text.substring(cap[0].length);
-      out += cap[0];
-      continue;
-    }
-
-    out += text;
-    break;
-  }
-
-  return out;
+  return convert(text, this.screen.program);
 };
 
 Element.prototype._parseAttr = function(lines) {
-  var dattr = this.sattr(this.style, this.style.fg, this.style.bg)
+  var dattr = this.sattr(this.style)
     , attr = dattr
     , attrs = []
     , line
@@ -2148,7 +2188,7 @@ Element.prototype._parseAttr = function(lines) {
 Element.prototype._align = function(line, width, align) {
   if (!align) return line;
 
-  var cline = line.replace(/\x1b\[[\d;]*m/g, '')
+  var cline = strip(line)
     , len = cline.length
     , s = width - len;
 
@@ -2288,7 +2328,7 @@ main:
   out.real = out;
 
   out.mwidth = out.reduce(function(current, line) {
-    line = line.replace(/\x1b\[[\d;]*m/g, '');
+    line = strip(line);
     return line.length > current
       ? line.length
       : current;
@@ -3166,7 +3206,7 @@ Element.prototype.render = function() {
 
   this.lpos = coords;
 
-  dattr = this.sattr(this.style, this.style.fg, this.style.bg);
+  dattr = this.sattr(this.style);
   attr = dattr;
 
   // If we're in a scrollable text box, check to
@@ -3319,8 +3359,7 @@ Element.prototype.render = function() {
 
   // Draw the border.
   if (this.border) {
-    battr = this.sattr(this.style.border,
-      this.style.border.fg, this.style.border.bg);
+    battr = this.sattr(this.style.border);
     y = yi;
     if (coords.notop) y = -1;
     for (x = xi; x < xl; x++) {
@@ -5238,7 +5277,7 @@ ProgressBar.prototype.render = function() {
     yi = yi + ((yl - yi) - (((yl - yi) * (this.filled / 100)) | 0));
   }
 
-  dattr = this.sattr(this, this.style.bar.fg, this.style.bar.bg);
+  dattr = this.sattr(this.style, this.style.bar.fg, this.style.bar.bg);
 
   this.screen.fillRegion(dattr, this.ch, xi, xl, yi, yl);
 
@@ -6535,3 +6574,7 @@ exports.DirManager = exports.dirmanager = DirManager;
 exports.Passbox = exports.passbox = Passbox;
 
 exports.helpers = helpers;
+
+exports.strip = strip;
+exports.convert = convert;
+exports.toText = toText;

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -1910,6 +1910,9 @@ function Element(options) {
 
   this.border = options.border;
   if (this.border) {
+    if ( this.border === true ) {
+      this.border = {};
+    }
     if (typeof this.border === 'string') {
       this.border = { type: this.border };
     }
@@ -1921,6 +1924,10 @@ function Element(options) {
       this.border.style.fg = this.border.fg;
       this.border.style.bg = this.border.bg;
     }
+    this.border.top = (this.border.top === false ? false : true);
+    this.border.left = (this.border.left === false ? false : true);
+    this.border.right = (this.border.right === false ? false : true);
+    this.border.bottom = (this.border.bottom === false ? false : true);
     this.style.border = this.border.style;
   }
 
@@ -3371,6 +3378,29 @@ Element.prototype.render = function() {
 
   // Draw the border.
   if (this.border) {
+    var borderChars, bTopLeft = 0, bTopRight = 1, bBottomLeft = 2, bBottomRight = 3, bLeftRight = 4, bTopBottom = 5;
+    if (this.border.type === 'line') {
+      borderChars = ['┌', '┐',
+                     '└', '┘',
+                     '│', '─'];
+    } else if (this.border.type === 'bold') {
+      borderChars = ['┏', '┓',
+                     '┗', '┛',
+                     '┃', '─'];
+    } else if (this.border.type === 'double') {
+      borderChars = ['╔', '╗',
+                     '╚', '╝',
+                     '║', '═'];
+    } else if (this.border.type === 'double-top') {
+      borderChars = ['╒', '╕',
+                     '╘', '╛',
+                     '│', '═'];
+    } else if (this.border.type === 'double-side') {
+      borderChars = ['╓', '╖',
+                     '╙', '╜',
+                     '║', '─'];
+    }
+
     battr = this.sattr(this.style.border);
     y = yi;
     if (coords.notop) y = -1;
@@ -3378,44 +3408,72 @@ Element.prototype.render = function() {
       if (!lines[y]) break;
       if (coords.noleft && x === xi) continue;
       if (coords.noright && x === xl - 1) continue;
-      if (this.border.type === 'line') {
-        if (x === xi) ch = '┌';
-        else if (x === xl - 1) ch = '┐';
-        else ch = '─';
-      } else if (this.border.type === 'bg') {
+      if ( borderChars ) {
+        if ( this.border.top ) {
+          if (x === xi) {
+            if ( this.border.left ) ch = borderChars[bTopLeft];
+            else ch = borderChars[bTopBottom];
+          }
+          else if (x === xl - 1) {
+            if ( this.border.right ) ch = borderChars[bTopRight];
+            else ch = borderChars[bTopBottom];
+          }
+          else ch = borderChars[bTopBottom];
+        }
+        else {
+          if ( x === xi && this.border.left || x === xl - 1 && this.border.right )
+            ch = borderChars[bLeftRight];
+          else
+            ch = this.border.ch;
+        }
+      }
+      else if (this.border.type === 'bg') {
         ch = this.border.ch;
       }
       cell = lines[y][x];
-      if (!cell) break;
-      if (battr !== cell[0] || ch !== cell[1]) {
-        lines[y][x][0] = battr;
-        lines[y][x][1] = ch;
-        lines[y].dirty = true;
+      if (cell) {
+        if (battr !== cell[0] || ch !== cell[1]) {
+          lines[y][x][0] = battr;
+          lines[y][x][1] = ch;
+          lines[y].dirty = true;
+        }
       }
     }
     y = yi + 1;
     for (; y < yl - 1; y++) {
       if (!lines[y]) break;
-      if (this.border.type === 'line') {
-        ch = '│';
-      } else if (this.border.type === 'bg') {
+      if ( borderChars ) {
+        if ( this.border.left ) ch = borderChars[bLeftRight];
+        else ch = this.border.ch;
+      }
+      else if (this.border.type === 'bg') {
         ch = this.border.ch;
       }
       cell = lines[y][xi];
-      if (!cell) break;
-      if (!coords.noleft)
-      if (battr !== cell[0] || ch !== cell[1]) {
-        lines[y][xi][0] = battr;
-        lines[y][xi][1] = ch;
-        lines[y].dirty = true;
+      if (cell) {
+        if (!coords.noleft)
+          if (battr !== cell[0] || ch !== cell[1]) {
+            lines[y][xi][0] = battr;
+            lines[y][xi][1] = ch;
+            lines[y].dirty = true;
+          }
+      }
+
+      if ( borderChars ) {
+        if ( this.border.right ) ch = borderChars[bLeftRight];
+        else ch = this.border.ch;
+      }
+      else if (this.border.type === 'bg') {
+        ch = this.border.ch;
       }
       cell = lines[y][xl - 1];
-      if (!cell) break;
-      if (!coords.noright)
-      if (battr !== cell[0] || ch !== cell[1]) {
-        lines[y][xl - 1][0] = battr;
-        lines[y][xl - 1][1] = ch;
-        lines[y].dirty = true;
+      if (cell) {
+        if (!coords.noright)
+          if (battr !== cell[0] || ch !== cell[1]) {
+            lines[y][xl - 1][0] = battr;
+            lines[y][xl - 1][1] = ch;
+            lines[y].dirty = true;
+          }
       }
     }
     y = yl - 1;
@@ -3424,19 +3482,34 @@ Element.prototype.render = function() {
       if (!lines[y]) break;
       if (coords.noleft && x === xi) continue;
       if (coords.noright && x === xl - 1) continue;
-      if (this.border.type === 'line') {
-        if (x === xi) ch = '└';
-        else if (x === xl - 1) ch = '┘';
-        else ch = '─';
-      } else if (this.border.type === 'bg') {
+      if ( borderChars ) {
+        if ( this.border.bottom ) {
+          if (x === xi) {
+            if ( this.border.left ) ch = borderChars[bBottomLeft];
+            else ch = borderChars[bTopBottom];
+          }
+          else if (x === xl - 1) {
+            if ( this.border.right ) ch = borderChars[bBottomRight];
+            else ch = borderChars[bTopBottom];
+          }
+          else ch = borderChars[bTopBottom];
+        }
+        else {
+          if ( x === xi && this.border.left ) ch = borderChars[bLeftRight];
+          else if ( x === xl - 1 && this.border.right ) ch = borderChars[bLeftRight];
+          else ch = this.border.ch;
+        }
+      }
+      else if (this.border.type === 'bg') {
         ch = this.border.ch;
       }
       cell = lines[y][x];
-      if (!cell) break;
-      if (battr !== cell[0] || ch !== cell[1]) {
-        lines[y][x][0] = battr;
-        lines[y][x][1] = ch;
-        lines[y].dirty = true;
+      if (cell) {
+        if (battr !== cell[0] || ch !== cell[1]) {
+          lines[y][x][0] = battr;
+          lines[y][x][1] = ch;
+          lines[y].dirty = true;
+        }
       }
     }
   }
@@ -3698,9 +3771,18 @@ function Line(options) {
 
   Box.call(this, options);
 
-  this.ch = !options.type || options.type === 'line'
-    ? orientation === 'horizontal' ? '─' : '│'
-    : options.ch || ' ';
+  options.type = options.type || 'line';
+  if ( options.ch ) {
+    this.ch = options.ch;
+  } else if ( !options.type || options.type === 'line' ) {
+    this.ch = orientation === 'horizontal' ? '─' : '│';
+  } else if ( options.type === 'bold' ) {
+    this.ch = orientation === 'horizontal' ? '─' : '┃'
+  } else if ( options.type === 'double' ) {
+    this.ch = orientation === 'horizontal' ? '═' : '║'
+  } else {
+    this.ch = ' ';
+  }
 
   this.border = {
     type: 'bg',

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -223,6 +223,13 @@ Node.prototype.insertAfter = function(element, other) {
   if (~i) this.insert(element, i + 1);
 };
 
+Node.prototype.removeAll = function(elements) {
+  elements = elements || this.children;
+  elements.forEach(function(element) {
+    this.remove(element);
+  }, this);
+};
+
 Node.prototype.remove = function(element) {
   if (element.parent !== this) return;
 

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -1873,6 +1873,7 @@ function Element(options) {
 
   if (!this.style) {
     this.style = {};
+    this.style.transparent = options.transparent;
     this.style.fg = options.fg;
     this.style.bg = options.bg;
     this.style.bold = options.bold;
@@ -2026,6 +2027,10 @@ Element.prototype.sattr = function(obj, fg, bg) {
   if (typeof inverse === 'function') inverse = inverse(this);
   if (typeof invisible === 'function') invisible = invisible(this);
 
+  if ( obj.transparent ) {
+    fg = this.parent && this.parent.style.fg;
+    bg = this.parent && this.parent.style.bg;
+  }
   if (typeof fg === 'function') fg = fg(this);
   if (typeof bg === 'function') bg = bg(this);
 

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -2087,6 +2087,13 @@ Element.prototype.focus = function() {
   return this.screen.focused = this;
 };
 
+Styles.forEach(function(style) {
+  Element.prototype[style] = function(on_off) {
+    on_off = (on_off === false ? false : true);
+    this.style[style] = on_off;
+  };
+});
+
 Element.prototype.setContent = function(content, noClear, noTags) {
   if (!noClear) this.clearPos();
   this.content = content || '';
@@ -6311,8 +6318,7 @@ Listbar.prototype.appendItem = function(item, callback) {
     options.left += this.ileft;
   }
 
-  ['bg', 'fg', 'bold', 'underline',
-   'blink', 'inverse', 'invisible'].forEach(function(name) {
+  Styles.forEach(function(name) {
     options.style[name] = function() {
       var attr = self.items[self.selected] === el
         ? self.style.selected[name]


### PR DESCRIPTION
Added new border types, refactored that code a bit, a few extra methods and options, and moved some of the text converting/stripping into functions, so I can use them in the CLI app I'm working on.

I'm confused by `Scrollbox`, btw.  It uses `this._clines` in many places, but _clines is only set in parseContent, which is only run on screens (because `detached` is only true for screens (?)).  I'll look into it more, but maybe you can smoke screen that for sanity.

Thanks for blessed, it's friggin' awesome.