### PR TITLE
Allow user formatting callback for items in FileManager's list.

### DIFF
--- a/lib/widget.js
+++ b/lib/widget.js
@@ -5470,6 +5470,28 @@ FileManager.prototype.__proto__ = List.prototype;
 
 FileManager.prototype.type = 'file-manager';
 
+function defaultDirectoryEntryFormatter (entry)
+{
+    if (entry.dir === true && entry.symlink === false) {
+        entry.text = '{light-blue-fg}' + entry.name + '{/light-blue-fg}/';
+    }
+    else if (entry.dir === false && entry.symlink === true) {
+      entry.text = '{light-cyan-fg}' + entry.name + '{/light-cyan-fg}@';
+    }
+    return entry
+}
+
+FileManager.prototype._directoryEntryFormatter = defaultDirectoryEntryFormatter;
+
+FileManager.prototype.useFormatter = function(formatterFn) {
+    if (formatterFn === null) {
+        this._directoryEntryFormatter = defaultDirectoryEntryFormatter;
+    }
+    else {
+        this._directoryEntryFormatter = formatterFn;
+    }
+}
+
 FileManager.prototype.refresh = function(cwd, callback) {
   if (!callback) {
     callback = cwd;
@@ -5509,24 +5531,27 @@ FileManager.prototype.refresh = function(cwd, callback) {
         ;
       }
 
-      if ((stat && stat.isDirectory()) || name === '..') {
-        dirs.push({
-          name: name,
-          text: '{light-blue-fg}' + name + '{/light-blue-fg}/',
-          dir: true
-        });
-      } else if (stat && stat.isSymbolicLink()) {
-        files.push({
-          name: name,
-          text: '{light-cyan-fg}' + name + '{/light-cyan-fg}@',
-          dir: false
-        });
-      } else {
-        files.push({
+      function makeEntry(name, opts) {
+        return {
           name: name,
           text: name,
-          dir: false
-        });
+          dir: opts.dir,
+          symlink: opts.symlink
+        }
+      }
+
+      if ((stat && stat.isDirectory()) || name === '..') {
+        var entry = makeEntry(name, {dir:true, symlink:false});
+        self._directoryEntryFormatter(entry)
+        dirs.push(entry);
+      } else if (stat && stat.isSymbolicLink()) {
+        var entry = makeEntry(name, {dir:false, symlink:true});
+        self._directoryEntryFormatter(entry)
+        files.push(entry);
+      } else {
+        var entry = makeEntry(name, {dir:false, symlink:false});
+        self._directoryEntryFormatter(entry)
+        files.push(entry);
       }
     });
 

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -5532,25 +5532,23 @@ FileManager.prototype.refresh = function(cwd, callback) {
       }
 
       function makeEntry(name, opts) {
-        return {
+        var entry = {
           name: name,
           text: name,
           dir: opts.dir,
           symlink: opts.symlink
-        }
+        };
+        return self._directoryEntryFormatter(entry)
       }
 
       if ((stat && stat.isDirectory()) || name === '..') {
         var entry = makeEntry(name, {dir:true, symlink:false});
-        self._directoryEntryFormatter(entry)
         dirs.push(entry);
       } else if (stat && stat.isSymbolicLink()) {
         var entry = makeEntry(name, {dir:false, symlink:true});
-        self._directoryEntryFormatter(entry)
         files.push(entry);
       } else {
         var entry = makeEntry(name, {dir:false, symlink:false});
-        self._directoryEntryFormatter(entry)
         files.push(entry);
       }
     });


### PR DESCRIPTION
Defaults to the existing implementation, which has been put in a function called `defaultDirectoryEntryFormatter()`.  Users can set their own via `fileManager.useFormatter(formatterFn)`, or if one wishes to fall back to the default formatter, simply call `fileManager.useFormatter(null)`.