### PR TITLE
use censor option as censor character if it is a string

### DIFF
--- a/lib/widgets/textbox.js
+++ b/lib/widgets/textbox.js
@@ -59,7 +59,8 @@ Textbox.prototype.setValue = function(value) {
     if (this.secret) {
       this.setContent('');
     } else if (this.censor) {
-      this.setContent(Array(this.value.length + 1).join('*'));
+      censorCharacter = typeof this.censor == 'string' && this.censor[0] || '*';
+      this.setContent(Array(this.value.length + 1).join(censorCharacter));
     } else {
       visible = -(this.width - this.iwidth - 1);
       val = this.value.replace(/\t/g, this.screen.tabc);


### PR DESCRIPTION
hello,

this little change allows me to use
```coffeescript
passwordBox = blessed.textbox
    censor: '●'
```
to get a slightly nicer password entry.
It would be nice if something similar could be done with the master version. 