### PR TITLE
Implement cursor moving and editing with arrow keys in the textarea widget.

### DIFF
--- a/lib/widgets/textarea.js
+++ b/lib/widgets/textarea.js
@@ -38,6 +38,9 @@ function Textarea(options) {
 
   this.value = options.value || '';
 
+  this.editorMargin = {left: 0, top: 0};
+
+  this._resetCursor();
   this.__updateCursor = this._updateCursor.bind(this);
   this.on('resize', this.__updateCursor);
   this.on('move', this.__updateCursor);
@@ -71,7 +74,111 @@ Textarea.prototype.__proto__ = Input.prototype;
 
 Textarea.prototype.type = 'textarea';
 
-Textarea.prototype._updateCursor = function(get) {
+Textarea.prototype._getLineContent = function(line) {
+  var lineContent = this._clines[line];
+
+  if (lineContent === undefined) {
+    lineContent = this._clines[this._clines.length - 1];
+  }
+
+  return lineContent;
+};
+
+Textarea.prototype._hasRetrun = function(line) {
+  if (line === undefined) {
+    var lpos = this._getCoords();
+    line = this.cursor.y - lpos.yi + this.itop;
+  }
+
+  return this._clines.rtof[line] !== this._clines.rtof[line + 1];
+};
+
+Textarea.prototype._cursorMaxRight = function(line, lpos) {
+  lpos = lpos ? lpos : this._getCoords();
+
+  var lineContent = this._getLineContent(line)
+    , cursorMax = lpos.xi + this.ileft + this.strWidth(lineContent);
+
+  return this._hasRetrun(line) || lineContent === '' ? cursorMax : cursorMax - 1;
+};
+
+Textarea.prototype._cursorMaxBottom = function(lpos) {
+  lpos = lpos ? lpos : this._getCoords();
+
+  return lpos.yi + this.itop + this._getMaxLine(lpos);
+};
+
+Textarea.prototype._getMaxLine = function(lpos) {
+  lpos = lpos ? lpos : this._getCoords();
+
+  var line = Math.min(
+    this._clines.length - 1 - (this.childBase || 0),
+    (lpos.yl - lpos.yi) - this.iheight - 1);
+
+  // When calling clearValue() on a full textarea with a border, the first
+  // argument in the above Math.min call ends up being -2. Make sure we stay
+  // positive.
+  return Math.max(0, line);
+};
+
+Textarea.prototype._setCursor = function(y, x) {
+  if (y !== null && y !== undefined) {
+    this.cursor.y = y;
+    this.editorCursor.y = y - this.editorMargin.top;
+  }
+
+  if (x !== null && x !== undefined) {
+    this.cursor.x = x;
+    this.editorCursor.x = x - this.editorMargin.left;
+  }
+};
+
+Textarea.prototype._applyCursor = function(lpos) {
+  lpos = lpos ? lpos : this._getCoords();
+
+  var cyMax = lpos.yl - lpos.yi + this.iheight;
+
+  if (this.cursor.y > cyMax) {
+    this._setCursorY(cyMax);
+  }
+
+  this.screen.program.cup(this.cursor.y, this.cursor.x);
+};
+
+Textarea.prototype._setCursorY = function(val) {
+  this._setCursor(val, null);
+};
+
+Textarea.prototype._setCursorX = function(val) {
+  this._setCursor(null, val);
+};
+
+Textarea.prototype._resetCursor = function() {
+  this.cursor = {x: undefined, y: undefined};
+  this.editorCursor = {x: 0, y: 0};
+};
+
+Textarea.prototype._indexOfContentOnCursor = function() {
+  var idx = 0;
+
+  // TODO: It has performance issue.
+  //       Need to change the "element.parseContent" function to improve this.
+  for (var y = 0; y < this.childBase + this.editorCursor.y; y++) {
+    idx = idx +
+      this._clines[y].replace(/\u0003/g, '').length +
+      (y > 0 && this._hasRetrun(y - 1) ? 1 : 0);
+  }
+
+  if (this._clines[y] !== undefined) {
+    idx = idx + 1 +
+      this._clines[y].slice(0, this.editorCursor.x).replace(/\u0003/g, '').length +
+      (y > 0 && this._hasRetrun(y - 1) ? 1 : 0);
+  }
+
+  return idx;
+};
+
+Textarea.prototype._updateCursor = function(get, input) {
   if (this.screen.focused !== this) {
     return;
   }
@@ -79,31 +186,25 @@ Textarea.prototype._updateCursor = function(get) {
   var lpos = get ? this.lpos : this._getCoords();
   if (!lpos) return;
 
-  var last = this._clines[this._clines.length - 1]
+  this.editorMargin.top = lpos.yi + this.itop;
+  this.editorMargin.left = lpos.xi + this.ileft;
+
+  var currentLine = this.childBase + this.cursor.y - this.editorMargin.top
     , program = this.screen.program
-    , line
     , cx
     , cy;
 
-  // Stop a situation where the textarea begins scrolling
-  // and the last cline appears to always be empty from the
-  // _typeScroll `+ '\n'` thing.
-  // Maybe not necessary anymore?
-  if (last === '' && this.value[this.value.length - 1] !== '\n') {
-    last = this._clines[this._clines.length - 2] || '';
+  var cyMax = this._cursorMaxBottom(lpos)
+    , cxMax = this._cursorMaxRight(currentLine, lpos)
+    , lineMax = this._clines.width + this.editorMargin.left;
+
+  if (this.cursor.x === undefined || this.cursor.y === undefined) {
+    this.cursor.y = cyMax;
+    this.cursor.x = cxMax;
+  } else {
+    cy = this.cursor.y;
+    cx = this.cursor.x;
   }
-
-  line = Math.min(
-    this._clines.length - 1 - (this.childBase || 0),
-    (lpos.yl - lpos.yi) - this.iheight - 1);
-
-  // When calling clearValue() on a full textarea with a border, the first
-  // argument in the above Math.min call ends up being -2. Make sure we stay
-  // positive.
-  line = Math.max(0, line);
-
-  cy = lpos.yi + this.itop + line;
-  cx = lpos.xi + this.ileft + this.strWidth(last);
 
   // XXX Not sure, but this may still sometimes
   // cause problems when leaving editor.
@@ -113,19 +214,57 @@ Textarea.prototype._updateCursor = function(get) {
 
   if (cy === program.y) {
     if (cx > program.x) {
-      program.cuf(cx - program.x);
+      if (cx <= cxMax) {
+        this._setCursorX(cx);
+      } else if (input && cx < lineMax) {
+        this._setCursorX(cxMax + 1);
+      } else if (cy < cyMax || cx === lineMax) {
+        // Go down and the start of below line
+        this._setCursor(this.cursor.y + 1, this.editorMargin.left);
+      } else {
+        this._setCursorX(cxMax);
+      }
     } else if (cx < program.x) {
-      program.cub(program.x - cx);
-    }
-  } else if (cx === program.x) {
-    if (cy > program.y) {
-      program.cud(cy - program.y);
-    } else if (cy < program.y) {
-      program.cuu(program.y - cy);
+      if (cx >= this.editorMargin.left) {
+        this._setCursorX(cx);
+      } else if (cy > this.editorMargin.top) {
+        // Go up and the end of upper line
+        this.cursor.x = this.editorMargin.left + this.strWidth(this._clines[currentLine - 1]);
+
+        if (!this._hasRetrun(currentLine - 1)) {
+          this.cursor.x = this.cursor.x - 1;
+        }
+
+        this._setCursor(this.cursor.y - 1, this.cursor.x);
+      } else {
+        this._setCursorX(this.editorMargin.left);
+      }
     }
   } else {
-    program.cup(cy, cx);
+    if (cy > program.y) {
+      if (input) {
+        this._setCursor(cy, this.editorMargin.left);
+      } else if (cy <= cyMax) {
+        var nextCxMax = this._cursorMaxRight(currentLine, lpos);
+        this._setCursor(cy, nextCxMax < cx ? nextCxMax : this.cursor.x);
+      } else {
+        this.scroll(1);
+        this._setCursorY(cyMax);
+      }
+    } else if (cy < program.y) {
+      if (cy >= this.editorMargin.top) {
+        var prevCxMax = this._cursorMaxRight(currentLine, lpos);
+        this._setCursor(cy, prevCxMax < cx ? prevCxMax : this.cursor.x);
+      } else {
+        this.scroll(-1);
+        this._setCursorY(this.editorMargin.top);
+      }
+    } else {
+      this._setCursor(cy, cx);
+    }
   }
+
+  this._applyCursor(lpos);
 };
 
 Textarea.prototype.input =
@@ -208,19 +347,42 @@ Textarea.prototype.readInput = function(callback) {
   this.on('blur', this.__done);
 };
 
+Textarea.prototype.moveCursorHorizonal = function (count, input) {
+  this.cursor.x = this.cursor.x + count;
+  this._updateCursor(null, input);
+};
+
+Textarea.prototype.moveCursorVertical = function (count, input) {
+  this.cursor.y = this.cursor.y + count;
+  this._updateCursor(null, input);
+};
+
+Textarea.prototype.moveCursorHorizonalByCharacter = function (direction, input) {
+  var cursorMove;
+
+  direction = direction === "left" ? -1 : 1;
+
+  if (!this.screen.fullUnicode) {
+    cursorMove = direction;
+  } else {
+    if (this._clines[this.editorCursor.y][this.editorCursor.x + direction] === '\u0003') {
+      cursorMove = direction * 2;
+    } else {
+      cursorMove = direction;
+    }
+  }
+
+  this.moveCursorHorizonal(cursorMove, input);
+};
+
 Textarea.prototype._listener = function(ch, key) {
   var done = this._done
-    , value = this.value;
+    , value = this.value
+    , charIdx;
 
   if (key.name === 'return') return;
   if (key.name === 'enter') {
     ch = '\n';
-  }
-
-  // TODO: Handle directional keys.
-  if (key.name === 'left' || key.name === 'right'
-      || key.name === 'up' || key.name === 'down') {
-    ;
   }
 
   if (this.options.keys && key.ctrl && key.name === 'e') {
@@ -231,22 +393,31 @@ Textarea.prototype._listener = function(ch, key) {
   // to the screen and screen buffer here.
   if (key.name === 'escape') {
     done(null, null);
+  } else if (key.name === 'left') {
+    this.moveCursorHorizonalByCharacter(key.name);
+  } else if (key.name === 'right') {
+    this.moveCursorHorizonalByCharacter(key.name);
+  } else if (key.name === 'up') {
+    this.moveCursorVertical(-1);
+  } else if (key.name === 'down') {
+    this.moveCursorVertical(1);
   } else if (key.name === 'backspace') {
     if (this.value.length) {
-      if (this.screen.fullUnicode) {
-        if (unicode.isSurrogate(this.value, this.value.length - 2)) {
-        // || unicode.isCombining(this.value, this.value.length - 1)) {
-          this.value = this.value.slice(0, -2);
-        } else {
-          this.value = this.value.slice(0, -1);
-        }
-      } else {
-        this.value = this.value.slice(0, -1);
-      }
+      this.moveCursorHorizonalByCharacter("left", true);
+      charIdx = this._indexOfContentOnCursor();
+      this.value = this.value.slice(0, charIdx - 1) + this.value.slice(charIdx);
     }
   } else if (ch) {
     if (!/^[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f]$/.test(ch)) {
-      this.value += ch;
+      charIdx = this._indexOfContentOnCursor();
+      this.value = this.value.slice(0, charIdx - 1) + ch + this.value.slice(charIdx - 1);
+
+      if(ch === '\n') {
+        this.moveCursorVertical(1, true);
+      } else {
+        // TODO: don't move when user change input method for CJK.
+        this.moveCursorHorizonal(unicode.charWidth(ch), true);
+      }
     }
   }
 
@@ -275,13 +446,16 @@ Textarea.prototype.setValue = function(value) {
     this.value = value;
     this._value = value;
     this.setContent(this.value);
-    this._typeScroll();
+    if (this.cursor.y && this.cursor.y >= this.height + this.iheight) {
+      this._typeScroll();
+    }
     this._updateCursor();
   }
 };
 
 Textarea.prototype.clearInput =
 Textarea.prototype.clearValue = function() {
+  this._resetCursor();
   return this.setValue('');
 };
 


### PR DESCRIPTION
Now, users can move with arrow keys and edit text anywhere on a cursor. And it works well with multi-byte characters but there is a little bug.

And actually It has a performance problem when you copy a large text and if we want fix this, fix "element.parseContent" function.

But I think, it's enough for editing small text and if someone want to edit large text, it's better to use slap-editor.