### PR TITLE
Add failing test for helpers.parseTags

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,5 @@
+var blessed = require('../'),
+    screen = blessed.screen();
+
+console.log(blessed.helpers.parseTags('{red-fg}This should be red.{/red-fg}'));
+console.log(blessed.helpers.parseTags('{green-bg}This should have a green background.{/green-bg}'));


### PR DESCRIPTION
a4d56fb moved the function from [here](https://github.com/chjj/blessed/blob/99f9d622e6053c62069f8fedb05141018fea9fdd/lib/widget.js#L9607-L9610) to its own file, but left the `Screen` variable undefined.

There seem to be no existing tests for the helpers.