### PR TITLE
Don't omit newlines after tags in the beginning of a line

### DIFF
--- a/lib/widgets/element.js
+++ b/lib/widgets/element.js
@@ -2019,7 +2019,8 @@ Element.prototype.render = function() {
         // If we're on the first cell and we find a newline and the last cell
         // of the last line was not a newline, let's just treat this like the
         // newline was already "counted".
-        if (x === xi && y !== yi && content[ci - 2] !== '\n') {
+        if (x === xi && y !== yi &&
+            helpers.stripTags(content.slice(0, ci - 1)).slice(-1)[0] !== '\n') {
           x--;
           continue;
         }


### PR DESCRIPTION
This patch fixes the bug in `Element.prototype.render` which causes newline characters that terminate lines that contain nothing but tags to be skipped from the output.

Minimal example:

```js
var blessed = require('blessed');

var screen = blessed.screen();
screen.key('q', function () {
  process.exit();
});

screen.append(blessed.box({
  content: 'first line\n{red-fg}{/red-fg}\nthird line\n',
  tags: true
}));

screen.render();
```

Notice that the second line is not being rendered at all.