### PR TITLE
Add cwd to terminal options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,7 @@ manager. Requires term.js and pty.js to be installed. See
 - __cursor__ - Can be `line`, `underline`, and `block`.
 - __terminal__ - Terminal name (Default: `xterm`).
 - __env__ - Object for process env.
+- __cwd__ - The directory for the shell to start in.  `$HOME` by default.
 - Other options similar to term.js'.
 
 ##### Properties:

--- a/lib/widgets/terminal.js
+++ b/lib/widgets/terminal.js
@@ -49,6 +49,8 @@ function Terminal(options) {
     || process.env.TERM
     || 'xterm';
 
+  this.cwd = options.cwd || process.env.HOME;
+
   this.bootstrap();
 }
 
@@ -219,7 +221,7 @@ Terminal.prototype.bootstrap = function() {
     name: this.termName,
     cols: this.width - this.iwidth,
     rows: this.height - this.iheight,
-    cwd: process.env.HOME,
+    cwd: this.cwd,
     env: this.options.env || process.env
   });
 


### PR DESCRIPTION
Adds the option `cwd` to the `terminal` widget.  Also updates the documentation accordingly.