### PR TITLE
prevents bigtext index out of bounds exception at certain widths

### DIFF
--- a/lib/widgets/bigtext.js
+++ b/lib/widgets/bigtext.js
@@ -140,7 +140,7 @@ BigText.prototype.render = function() {
         if (this.fch && this.fch !== ' ') {
           lines[y][x + mx][0] = dattr;
           lines[y][x + mx][1] = mcell === 1 ? this.fch : this.ch;
-        } else {
+        } else if (lines[y][x + mx]) {
           lines[y][x + mx][0] = mcell === 1 ? attr : dattr;
           lines[y][x + mx][1] = mcell === 1 ? ' ' : this.ch;
         }


### PR DESCRIPTION
I'm seeing this at certain widths with BigText.
```
TypeError: Cannot set property '0' of undefined
    at BigText.render (/home/alivesay/working/blessed/lib/widgets/bigtext.js:144:31)
    at /home/alivesay/working/blessed/lib/widgets/screen.js:738:8
    at Array.forEach (native)
    at Screen.render (/home/alivesay/working/blessed/lib/widgets/screen.js:735:17)
    at Program.<anonymous> (/home/alivesay/working/blessed/lib/widgets/screen.js:146:10)
    at emitNone (events.js:67:13)
    at Program.emit (events.js:166:7)
    at /home/alivesay/working/blessed/lib/program.js:440:15
    at Array.forEach (native)
    at resize (/home/alivesay/working/blessed/lib/program.js:436:23)
```
This PR guards against this error, though I suspect someone more familiar with the rendering loop might see a more elegant solution...