### PR TITLE
Adds options.scrollStep to List

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ A scrollable list which can display selectable items.
 ##### Properties:
 
 - Inherits all from Box.
+- __scrollStep__ - Sets selection increments for mouse scrolling (Default: `2`)
 
 ##### Events:
 

--- a/lib/widgets/list.js
+++ b/lib/widgets/list.js
@@ -93,11 +93,11 @@ function List(options) {
   if (options.mouse) {
     this.screen._listenMouse(this);
     this.on('element wheeldown', function() {
-      self.select(self.selected + 2);
+      self.select(self.selected + (options.scrollStep || 2));
       self.screen.render();
     });
     this.on('element wheelup', function() {
-      self.select(self.selected - 2);
+      self.select(self.selected - (options.scrollStep || 2));
       self.screen.render();
     });
   }


### PR DESCRIPTION
This adds a config option `scrollStep` to List to set how many items are scrolled on wheelup/wheeldown events.