### PR TITLE
Allows styling of Loading spinner

### DIFF
--- a/lib/widgets/loading.js
+++ b/lib/widgets/loading.js
@@ -32,7 +32,8 @@ function Loading(options) {
     left: 1,
     right: 1,
     height: 1,
-    content: '|'
+    content: '|',
+    style: options.style
   });
 }
 


### PR DESCRIPTION
This adds `options.style` to Loading options to allow styling of the spinner icon element.