### PR TITLE
Remove listbar keys events handlers when setting new items

### DIFF
--- a/lib/widgets/listbar.js
+++ b/lib/widgets/listbar.js
@@ -141,6 +141,15 @@ Listbar.prototype.setItems = function(commands) {
     el.detach();
   });
 
+  // Remove keys event handlers if exist
+  if (this.commands && this.commands.length) {
+	  this.commands.forEach(function(cmd) {
+		if (cmd.callback && cmd.keys) {
+		  self.screen.unkey(cmd.keys, cmd.callback);
+		}
+	  });
+  }
+
   this.items = [];
   this.ritems = [];
   this.commands = [];


### PR DESCRIPTION
In my app I've main navigation `listbar` which switches sections and subnavigation `listbar` which fully depends on currently selected section.

I set new items to subnav `listbar` when app page is changed, since command key handlers are not unbound while setting new items there is a mess active event handlers eventually.

I propose to unbind old commands when setting new ones.