### PR TITLE
Enabling individual item style on lists

### DIFF
--- a/lib/widgets/list.js
+++ b/lib/widgets/list.js
@@ -225,7 +225,7 @@ List.prototype.__proto__ = Box.prototype;
 
 List.prototype.type = 'list';
 
-List.prototype.createItem = function(content) {
+List.prototype.createItem = function(content, itemStyle) {
   var self = this;
 
   // Note: Could potentially use Button here.
@@ -261,7 +261,7 @@ List.prototype.createItem = function(content) {
     options[name] = function() {
       var attr = self.items[self.selected] === item && self.interactive
         ? self.style.selected[name]
-        : self.style.item[name];
+        : itemStyle && itemStyle[name] ? itemStyle[name] : self.style.item[name];
       if (typeof attr === 'function') attr = attr(item);
       return attr;
     };
@@ -293,10 +293,10 @@ List.prototype.createItem = function(content) {
 
 List.prototype.add =
 List.prototype.addItem =
-List.prototype.appendItem = function(content) {
+List.prototype.appendItem = function(content, itemStyle) {
   content = typeof content === 'string' ? content : content.getContent();
 
-  var item = this.createItem(content);
+  var item = this.createItem(content, itemStyle);
   item.position.top = this.items.length;
   if (!this.screen.autoPadding) {
     item.position.top = this.itop + this.items.length;
@@ -404,8 +404,8 @@ List.prototype.setItems = function(items) {
   this.emit('set items');
 };
 
-List.prototype.pushItem = function(content) {
-  this.appendItem(content);
+List.prototype.pushItem = function(content, itemStyle) {
+  this.appendItem(content, itemStyle);
   return this.items.length;
 };
 

--- a/lib/widgets/list.js
+++ b/lib/widgets/list.js
@@ -260,7 +260,7 @@ List.prototype.createItem = function(content, itemStyle) {
    'blink', 'inverse', 'invisible'].forEach(function(name) {
     options[name] = function() {
       var attr = self.items[self.selected] === item && self.interactive
-        ? self.style.selected[name]
+        ? itemStyle && itemStyle[name] ? itemStyle[name] : self.style.selected[name]
         : itemStyle && itemStyle[name] ? itemStyle[name] : self.style.item[name];
       if (typeof attr === 'function') attr = attr(item);
       return attr;


### PR DESCRIPTION
This commit enables individual item styling on the list widget.

With this change now you can pass an additional argument to the `add`, `appendItem` and `pushItem` methods, with the style of that particular item of the list, see below an example

``` javascript
var blessed = require("/home/erick/projects/blessed/index");

var screen = blessed.screen({
  smartCSR: true
});

screen.title = "Test";

// Quit on Escape, q, or Control-C.
screen.key(['escape', 'q', 'C-c'], function(ch, key) {
  return process.exit(0);
});

var list = blessed.list({
  vi: true,
  keys: true,
  border: { type: "line" },
  style: {
    selected: {
      bg: "blue"
    }
  }
});

list.add("First item", {
  fg: "red"
});
list.add("Second item", {
  fg: "green"
});
list.pushItem({
  getContent: function() { return "Third item" }
}, {
  fg: "blue"
})

list.focus();
screen.append(list);

screen.render();
```
