### PR TITLE
Fix iterm2 CopyToClipboard 

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -1809,7 +1809,7 @@ Program.prototype.__defineSetter__('title', function(title) {
 //  }
 Program.prototype.copyToClipboard = function(text) {
   if (this.isiTerm2) {
-    this._twrite('\x1b]50;CopyToCliboard=' + text + '\x07');
+    this._twrite('\x1b]50;CopyToClipboard=\x07' + text + '\x1b]50;EndCopy\x07');
     return true;
   }
   return false;


### PR DESCRIPTION
Looks like this method never actually worked, even in iTerm, now it should. 

Ideally, it should also fall back to using pbcopy etc, but I only care about iTerm right now.
