### PR TITLE
allow to update the border object after Element initialization

### DIFF
--- a/lib/widgets/element.js
+++ b/lib/widgets/element.js
@@ -116,25 +116,7 @@ function Element(options) {
   };
 
   this.border = options.border;
-  if (this.border) {
-    if (typeof this.border === 'string') {
-      this.border = { type: this.border };
-    }
-    this.border.type = this.border.type || 'bg';
-    if (this.border.type === 'ascii') this.border.type = 'line';
-    this.border.ch = this.border.ch || ' ';
-    this.style.border = this.style.border || this.border.style;
-    if (!this.style.border) {
-      this.style.border = {};
-      this.style.border.fg = this.border.fg;
-      this.style.border.bg = this.border.bg;
-    }
-    //this.border.style = this.style.border;
-    if (this.border.left == null) this.border.left = true;
-    if (this.border.top == null) this.border.top = true;
-    if (this.border.right == null) this.border.right = true;
-    if (this.border.bottom == null) this.border.bottom = true;
-  }
+
 
   // if (options.mouse || options.clickable) {
   if (options.clickable) {
@@ -776,6 +758,36 @@ Element.prototype.enableInput = function() {
   this.screen._listenMouse(this);
   this.screen._listenKeys(this);
 };
+
+Object.defineProperty(Element.prototype, 'border', {
+    get: function() {
+      return this._border;
+    },
+    set: function(_border) {
+      var border = Object.assign({}, _border);
+      if (border) {
+        if (typeof border === 'string') {
+          border = { type: border };
+        }
+        border.type = border.type || 'bg';
+        if (border.type === 'ascii') border.type = 'line';
+        border.ch = border.ch || ' ';
+        this.style.border = this.style.border || border.style;
+        if (!this.style.border) {
+          this.style.border = {};
+          this.style.border.fg = border.fg;
+          this.style.border.bg = border.bg;
+        }
+        //border.style = this.style.border;
+        if (border.left == null) border.left = true;
+        if (border.top == null) border.top = true;
+        if (border.right == null) border.right = true;
+        if (border.bottom == null) border.bottom = true;
+        this._border = border;
+      }
+      return border;
+    }
+});
 
 Element.prototype.__defineGetter__('draggable', function() {
   return this._draggable === true;


### PR DESCRIPTION
Previously, setting the border object after the Element initialization will generate an error in the next render() because `this.style.border` will still be null. With this patch, the border related logic is stored in the property setter, so at least the application doesn't crash.
