### PR TITLE
button: don't focus on press

### DIFF
--- a/lib/widgets/button.js
+++ b/lib/widgets/button.js
@@ -48,7 +48,6 @@ Button.prototype.__proto__ = Input.prototype;
 Button.prototype.type = 'button';
 
 Button.prototype.press = function() {
-  this.focus();
   this.value = true;
   var result = this.emit('press');
   delete this.value;


### PR DESCRIPTION
Automatically focusing a button on 'press' results in a 'blur' being
emitted on the thing that loses focus which can have undesired side
effects.

E.g. during a Textarea readInput a blur is taken to imply that the user
navigated away from the textarea and so the input read is cancelled and
a value of null is passed to the input callback.

Since a Prompt is based on a Textarea this in turn means the mouse can't
be used to press the Okay button without a blur event being triggered
which will result in a prompt value of null instead of the user's
entered value.

Fixes: #249
