### PR TITLE
Detect native stream keypress events and bail.

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -26,6 +26,7 @@
 // IN THE SOFTWARE.
 
 var EventEmitter = require('events').EventEmitter;
+var Log = require('./log');
 
 // NOTE: node <=v0.8.x has no EventEmitter.listenerCount
 function listenerCount(stream, event) {
@@ -38,8 +39,26 @@ function listenerCount(stream, event) {
  * accepts a readable Stream instance and makes it emit "keypress" events
  */
 
-function emitKeypressEvents(stream) {
+function emitKeypressEvents(stream, program) {
   if (stream._keypressDecoder) return;
+  // Check if the internal readline.emitKeypressEvents() was called.
+  // If it was, we have to bail out, or the user will get double keypresses.
+  // Unfortunately, this also means that mouse events will not work as intended.
+  if (Object.getOwnPropertySymbols) {
+    var symbols = Object.getOwnPropertySymbols(stream);
+    var nativeCalled = false;
+    for (var i = 0; i < symbols.length; i++) {
+      if (symbols[i].toString() === 'Symbol(keypress-decoder)') nativeCalled = true;
+    }
+    if (nativeCalled) {
+      // See https://github.com/chjj/blessed/issues/92 for more on this
+      program.emit('warning', 'Blessed has an incompatibility with the ' +
+        'default keypress emitter on process.stdin. This may have been ' +
+        'added if you or a library instantiated a readline instance. ' +
+        'This is not fatal, but mouse events may be interpreted badly.');
+      return;
+    }
+  }
   var StringDecoder = require('string_decoder').StringDecoder; // lazy load
   stream._keypressDecoder = new StringDecoder('utf8');
 

--- a/lib/program.js
+++ b/lib/program.js
@@ -419,7 +419,7 @@ Program.prototype._listenInput = function() {
     });
   });
 
-  keys.emitKeypressEvents(this.input);
+  keys.emitKeypressEvents(this.input, this);
 };
 
 Program.prototype._listenOutput = function() {


### PR DESCRIPTION
This is because blessed is running its own version of
readline's `emitKeypressEvents()` to handle mouse escape
codes. Both implementations can be added to the same stream,
resulting in double keypress events.

Refusing to add the handler if another is present does not
fix the mouse escape codes, but it will warn and fix the
double input.

See #92 and [nodejs/node#9447](https://github.com/nodejs/node/pull/9447).