### PR TITLE
List: add getSelected method

### DIFF
--- a/lib/widgets/list.js
+++ b/lib/widgets/list.js
@@ -533,6 +533,10 @@ List.prototype.select = function(index) {
   this.emit('select item', this.items[this.selected], this.selected);
 };
 
+List.prototype.getSelected = function() {
+  return this.selected;
+}
+
 List.prototype.move = function(offset) {
   this.select(this.selected + offset);
 };


### PR DESCRIPTION
This makes it possible to do things with the currently focused list item instead of just items the user "selects".

As an aside @chjj what do you think about renaming "selected/select" to "focused/focus"? It seems to more clearly describe what it is. Also solves the name collision with `enterSelected`.  