### PR TITLE
Individual cell alignment per column

### DIFF
--- a/lib/widgets/listtable.js
+++ b/lib/widgets/listtable.js
@@ -34,6 +34,7 @@ function ListTable(options) {
   options.style.cell = options.style.cell || {};
   this.__align = options.align || 'center';
   delete options.align;
+  options.cellAligns = options.cellAligns || {};
 
   options.style.selected = options.style.cell.selected;
   options.style.item = options.style.cell;
@@ -125,6 +126,8 @@ ListTable.prototype.setData = function(rows) {
       if (i !== 0) {
         text += ' ';
       }
+
+      align = self.options.cellAligns[i] || self.__align;
 
       while (clen < width) {
         if (align === 'center') {

--- a/lib/widgets/table.js
+++ b/lib/widgets/table.js
@@ -29,6 +29,7 @@ function Table(options) {
   options.style.header = options.style.header || {};
   options.style.cell = options.style.cell || {};
   options.align = options.align || 'center';
+  options.cellAligns = options.cellAligns || {};
 
   // Regular tables do not get custom height (this would
   // require extra padding). Maybe add in the future.
@@ -127,6 +128,8 @@ Table.prototype.setData = function(rows) {
       if (i !== 0) {
         text += ' ';
       }
+
+      align = self.options.cellAligns[i] || self.align;
 
       while (clen < width) {
         if (align === 'center') {


### PR DESCRIPTION
Align only the second column to the left:
```
var table = blessed.table({align: 'right', cellAligns: [null, 'left']});
var listtable = blessed.listtable({align: 'right', cellAligns: [null, 'left']});
```
