### PR TITLE
Add mouse option to widget-scrollable-boxes

### DIFF
--- a/test/widget-scrollable-boxes.js
+++ b/test/widget-scrollable-boxes.js
@@ -21,6 +21,7 @@ var box = blessed.box({
   border: 'line',
   content: 'foobar',
   keys: true,
+  mouse: true,
   vi: true,
   alwaysScroll: true,
   scrollbar: {


### PR DESCRIPTION
Added the `mouse: true` option to the widget-scrollable-boxes example. I was trying for hours to figure out why my box wouldn't scroll until I finally found this option. Also, the demo doesn't actually scroll until we add this option.