### PR TITLE
Fix scrollbar not appearing on ListTable

### DIFF
--- a/lib/widgets/table.js
+++ b/lib/widgets/table.js
@@ -64,6 +64,10 @@ Table.prototype._calculateMaxes = function() {
 
   if (this.detached) return;
 
+  // Tables that are also ListTables can have scrollbars, which means we need
+  // to calculate with one fewer width cells
+  var width = this.scrollbar ? this.width - 1 : this.width;
+
   this.rows = this.rows || [];
 
   this.rows.forEach(function(row) {
@@ -83,12 +87,12 @@ Table.prototype._calculateMaxes = function() {
   // XXX There might be an issue with resizing where on the first resize event
   // width appears to be less than total if it's a percentage or left/right
   // combination.
-  if (this.width < total) {
+  if (width < total) {
     delete this.position.width;
   }
 
   if (this.position.width != null) {
-    var missing = this.width - total;
+    var missing = width - total;
     var w = missing / maxes.length | 0;
     var wr = missing % maxes.length;
     maxes = maxes.map(function(max, i) {


### PR DESCRIPTION
Not sure how maintained this project is these days but thought I'd contribute the fix just in case anyone else encounters this issue.

Feel free to ask for a reproduction of the issue if that's useful!

---

Previously the ListTable would overwrite the scrollbar with content or whitespace (depending on what it thought should be in those cells).