### PR TITLE
Fix table scrolling, add selectrow event.

### DIFF
--- a/lib/widgets/listtable.js
+++ b/lib/widgets/listtable.js
@@ -182,7 +182,12 @@ ListTable.prototype.select = function(i) {
   if (i <= this.childBase) {
     this.setScroll(this.childBase - 1);
   }
-  return this._select(i);
+  this._select(i);
+  // Correct scrolling for header offset.
+  this.scrollTo(this.selected - 1);
+  if (this.rows && this.selected) {
+    this.emit('selectrow', this.rows[this.selected], this.selected)
+  }
 };
 
 ListTable.prototype.render = function() {


### PR DESCRIPTION
This fixes a bug and adds a small feature, both related to ListTables:

- The auto scrolling in ListTables does not take into account the fixed header row, thus alwas being one off. 
- Emit an event when a table row is selected (existing events are not triggered consistently)