### PR TITLE
adding foreground color definition to fix #315

### DIFF
--- a/lib/widgets/prompt.js
+++ b/lib/widgets/prompt.js
@@ -34,7 +34,8 @@ function Prompt(options) {
     height: 1,
     left: 2,
     right: 2,
-    bg: 'black'
+    bg: 'black',
+    fg: 'white'
   });
 
   this._.okay = new Button({
@@ -46,6 +47,7 @@ function Prompt(options) {
     content: 'Okay',
     align: 'center',
     bg: 'black',
+    fg: 'white',
     hoverBg: 'blue',
     autoFocus: false,
     mouse: true
@@ -61,6 +63,7 @@ function Prompt(options) {
     content: 'Cancel',
     align: 'center',
     bg: 'black',
+    fg: 'white',
     hoverBg: 'blue',
     autoFocus: false,
     mouse: true


### PR DESCRIPTION
Detailed description of the bug in #315, this patch should fix it by giving explicit values to `fg` for the internal widgets.