### PR TITLE
add "pkg" entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   },
   "browserify": {
     "transform": ["./browser/transform.js"]
+  },
+  "pkg": {
+    "scripts": "lib/widgets/*.js"
   }
 }


### PR DESCRIPTION
To whitelist the dynamically required files in the `lib/widgets` dir when building with [pkg](https://github.com/zeit/pkg).

Closes #298.