### PR TITLE
Update pty.js to node-pty.

### DIFF
--- a/lib/widgets/terminal.js
+++ b/lib/widgets/terminal.js
@@ -215,7 +215,7 @@ Terminal.prototype.bootstrap = function() {
     return;
   }
 
-  this.pty = require('pty.js').fork(this.shell, this.args, {
+  this.pty = require('node-pty').fork(this.shell, this.args, {
     name: this.termName,
     cols: this.width - this.iwidth,
     rows: this.height - this.iheight,


### PR DESCRIPTION
pty.js is not being updated, while node-pty still is. Additionally, pty.js does not run on windows, while node-pty has windows support.

closes #327 