### PR TITLE
Don't override prefix if already given

### DIFF
--- a/lib/widgets/listbar.js
+++ b/lib/widgets/listbar.js
@@ -192,7 +192,7 @@ Listbar.prototype.appendItem = function(item, callback) {
     };
   }
 
-  if (cmd.keys && cmd.keys[0]) {
+  if (cmd.prefix == null && cmd.keys && cmd.keys[0]) {
     cmd.prefix = cmd.keys[0];
   }
 


### PR DESCRIPTION
Keys might be `['enter']`, but I want the prefix to say `Enter`.