### PR TITLE
show error before trying to destroy screen(s)

### DIFF
--- a/lib/widgets/screen.js
+++ b/lib/widgets/screen.js
@@ -212,11 +212,14 @@ Screen.bind = function(screen) {
     if (process.listeners('uncaughtException').length > 1) {
       return;
     }
+    
+    err = err || new Error('Uncaught Exception.');
+    console.error(err.stack ? err.stack + '' : err + '');
+    
     Screen.instances.slice().forEach(function(screen) {
       screen.destroy();
     });
-    err = err || new Error('Uncaught Exception.');
-    console.error(err.stack ? err.stack + '' : err + '');
+    
     nextTick(function() {
       process.exit(1);
     });


### PR DESCRIPTION
In cases where a screen fails to show due to some process-level exception, and the app is shutting down, the caught exception may never be shown. Moving the error-displaying-code above the screen-destroying code fixes this.