### PR TITLE
edit: bugfix for carousel repl focus

### DIFF
--- a/lib/widgets/element.js
+++ b/lib/widgets/element.js
@@ -8,16 +8,16 @@
  * Modules
  */
 
-var assert = require('assert');
+var assert = require("assert");
 
-var colors = require('../colors')
-  , unicode = require('../unicode');
+var colors = require("../colors"),
+  unicode = require("../unicode");
 
 var nextTick = global.setImmediate || process.nextTick.bind(process);
 
-var helpers = require('../helpers');
+var helpers = require("../helpers");
 
-var Node = require('./node');
+var Node = require("./node");
 
 /**
  * Element
@@ -33,12 +33,15 @@ function Element(options) {
   options = options || {};
 
   // Workaround to get a `scrollable` option.
-  if (options.scrollable && !this._ignore && this.type !== 'scrollable-box') {
-    var ScrollableBox = require('./scrollablebox');
-    Object.getOwnPropertyNames(ScrollableBox.prototype).forEach(function(key) {
-      if (key === 'type') return;
-      Object.defineProperty(this, key,
-        Object.getOwnPropertyDescriptor(ScrollableBox.prototype, key));
+  if (options.scrollable && !this._ignore && this.type !== "scrollable-box") {
+    var ScrollableBox = require("./scrollablebox");
+    Object.getOwnPropertyNames(ScrollableBox.prototype).forEach(function (key) {
+      if (key === "type") return;
+      Object.defineProperty(
+        this,
+        key,
+        Object.getOwnPropertyDescriptor(ScrollableBox.prototype, key)
+      );
     }, this);
     this._ignore = true;
     ScrollableBox.call(this, options);
@@ -56,15 +59,17 @@ function Element(options) {
     top: options.top,
     bottom: options.bottom,
     width: options.width,
-    height: options.height
+    height: options.height,
   };
 
-  if (options.position.width === 'shrink'
-      || options.position.height === 'shrink') {
-    if (options.position.width === 'shrink') {
+  if (
+    options.position.width === "shrink" ||
+    options.position.height === "shrink"
+  ) {
+    if (options.position.width === "shrink") {
       delete options.position.width;
     }
-    if (options.position.height === 'shrink') {
+    if (options.position.height === "shrink") {
       delete options.position.height;
     }
     options.shrink = true;
@@ -92,19 +97,19 @@ function Element(options) {
 
   this.hidden = options.hidden || false;
   this.fixed = options.fixed || false;
-  this.align = options.align || 'left';
-  this.valign = options.valign || 'top';
+  this.align = options.align || "left";
+  this.valign = options.valign || "top";
   this.wrap = options.wrap !== false;
   this.shrink = options.shrink;
   this.fixed = options.fixed;
-  this.ch = options.ch || ' ';
+  this.ch = options.ch || " ";
 
-  if (typeof options.padding === 'number' || !options.padding) {
+  if (typeof options.padding === "number" || !options.padding) {
     options.padding = {
       left: options.padding,
       top: options.padding,
       right: options.padding,
-      bottom: options.padding
+      bottom: options.padding,
     };
   }
 
@@ -112,17 +117,17 @@ function Element(options) {
     left: options.padding.left || 0,
     top: options.padding.top || 0,
     right: options.padding.right || 0,
-    bottom: options.padding.bottom || 0
+    bottom: options.padding.bottom || 0,
   };
 
   this.border = options.border;
   if (this.border) {
-    if (typeof this.border === 'string') {
+    if (typeof this.border === "string") {
       this.border = { type: this.border };
     }
-    this.border.type = this.border.type || 'bg';
-    if (this.border.type === 'ascii') this.border.type = 'line';
-    this.border.ch = this.border.ch || ' ';
+    this.border.type = this.border.type || "bg";
+    if (this.border.type === "ascii") this.border.type = "line";
+    this.border.ch = this.border.ch || " ";
     this.style.border = this.style.border || this.border.style;
     if (!this.style.border) {
       this.style.border = {};
@@ -147,7 +152,7 @@ function Element(options) {
 
   this.parseTags = options.parseTags || options.tags;
 
-  this.setContent(options.content || '', true);
+  this.setContent(options.content || "", true);
 
   if (options.label) {
     this.setLabel(options.label);
@@ -158,33 +163,35 @@ function Element(options) {
   }
 
   // TODO: Possibly move this to Node for onScreenEvent('mouse', ...).
-  this.on('newListener', function fn(type) {
+  this.on("newListener", function fn(type) {
     // type = type.split(' ').slice(1).join(' ');
-    if (type === 'mouse'
-      || type === 'click'
-      || type === 'mouseover'
-      || type === 'mouseout'
-      || type === 'mousedown'
-      || type === 'mouseup'
-      || type === 'mousewheel'
-      || type === 'wheeldown'
-      || type === 'wheelup'
-      || type === 'mousemove') {
+    if (
+      type === "mouse" ||
+      type === "click" ||
+      type === "mouseover" ||
+      type === "mouseout" ||
+      type === "mousedown" ||
+      type === "mouseup" ||
+      type === "mousewheel" ||
+      type === "wheeldown" ||
+      type === "wheelup" ||
+      type === "mousemove"
+    ) {
       self.screen._listenMouse(self);
-    } else if (type === 'keypress' || type.indexOf('key ') === 0) {
+    } else if (type === "keypress" || type.indexOf("key ") === 0) {
       self.screen._listenKeys(self);
     }
   });
 
-  this.on('resize', function() {
+  this.on("resize", function () {
     self.parseContent();
   });
 
-  this.on('attach', function() {
+  this.on("attach", function () {
     self.parseContent();
   });
 
-  this.on('detach', function() {
+  this.on("detach", function () {
     delete self.lpos;
   });
 
@@ -206,9 +213,14 @@ function Element(options) {
     if (options.effects.focus) options.focusEffects = options.effects.focus;
   }
 
-  [['hoverEffects', 'mouseover', 'mouseout', '_htemp'],
-   ['focusEffects', 'focus', 'blur', '_ftemp']].forEach(function(props) {
-    var pname = props[0], over = props[1], out = props[2], temp = props[3];
+  [
+    ["hoverEffects", "mouseover", "mouseout", "_htemp"],
+    ["focusEffects", "focus", "blur", "_ftemp"],
+  ].forEach(function (props) {
+    var pname = props[0],
+      over = props[1],
+      out = props[2],
+      temp = props[3];
     self.screen.setEffects(self, self, over, out, self.options[pname], temp);
   });
 
@@ -223,18 +235,18 @@ function Element(options) {
 
 Element.prototype.__proto__ = Node.prototype;
 
-Element.prototype.type = 'element';
+Element.prototype.type = "element";
 
-Element.prototype.__defineGetter__('focused', function() {
+Element.prototype.__defineGetter__("focused", function () {
   return this.screen.focused === this;
 });
 
-Element.prototype.sattr = function(style, fg, bg) {
-  var bold = style.bold
-    , underline = style.underline
-    , blink = style.blink
-    , inverse = style.inverse
-    , invisible = style.invisible;
+Element.prototype.sattr = function (style, fg, bg) {
+  var bold = style.bold,
+    underline = style.underline,
+    blink = style.blink,
+    inverse = style.inverse,
+    invisible = style.invisible;
 
   // if (arguments.length === 1) {
   if (fg == null && bg == null) {
@@ -244,45 +256,47 @@ Element.prototype.sattr = function(style, fg, bg) {
 
   // This used to be a loop, but I decided
   // to unroll it for performance's sake.
-  if (typeof bold === 'function') bold = bold(this);
-  if (typeof underline === 'function') underline = underline(this);
-  if (typeof blink === 'function') blink = blink(this);
-  if (typeof inverse === 'function') inverse = inverse(this);
-  if (typeof invisible === 'function') invisible = invisible(this);
+  if (typeof bold === "function") bold = bold(this);
+  if (typeof underline === "function") underline = underline(this);
+  if (typeof blink === "function") blink = blink(this);
+  if (typeof inverse === "function") inverse = inverse(this);
+  if (typeof invisible === "function") invisible = invisible(this);
 
-  if (typeof fg === 'function') fg = fg(this);
-  if (typeof bg === 'function') bg = bg(this);
+  if (typeof fg === "function") fg = fg(this);
+  if (typeof bg === "function") bg = bg(this);
 
   // return (this.uid << 24)
   //   | ((this.dockBorders ? 32 : 0) << 18)
-  return ((invisible ? 16 : 0) << 18)
-    | ((inverse ? 8 : 0) << 18)
-    | ((blink ? 4 : 0) << 18)
-    | ((underline ? 2 : 0) << 18)
-    | ((bold ? 1 : 0) << 18)
-    | (colors.convert(fg) << 9)
-    | colors.convert(bg);
+  return (
+    ((invisible ? 16 : 0) << 18) |
+    ((inverse ? 8 : 0) << 18) |
+    ((blink ? 4 : 0) << 18) |
+    ((underline ? 2 : 0) << 18) |
+    ((bold ? 1 : 0) << 18) |
+    (colors.convert(fg) << 9) |
+    colors.convert(bg)
+  );
 };
 
-Element.prototype.onScreenEvent = function(type, handler) {
-  var listeners = this._slisteners = this._slisteners || [];
+Element.prototype.onScreenEvent = function (type, handler) {
+  var listeners = (this._slisteners = this._slisteners || []);
   listeners.push({ type: type, handler: handler });
   this.screen.on(type, handler);
 };
 
-Element.prototype.onceScreenEvent = function(type, handler) {
-  var listeners = this._slisteners = this._slisteners || [];
+Element.prototype.onceScreenEvent = function (type, handler) {
+  var listeners = (this._slisteners = this._slisteners || []);
   var entry = { type: type, handler: handler };
   listeners.push(entry);
-  this.screen.once(type, function() {
+  this.screen.once(type, function () {
     var i = listeners.indexOf(entry);
     if (~i) listeners.splice(i, 1);
     return handler.apply(this, arguments);
   });
 };
 
-Element.prototype.removeScreenEvent = function(type, handler) {
-  var listeners = this._slisteners = this._slisteners || [];
+Element.prototype.removeScreenEvent = function (type, handler) {
+  var listeners = (this._slisteners = this._slisteners || []);
   for (var i = 0; i < listeners.length; i++) {
     var listener = listeners[i];
     if (listener.type === type && listener.handler === handler) {
@@ -296,8 +310,8 @@ Element.prototype.removeScreenEvent = function(type, handler) {
   this.screen.removeListener(type, handler);
 };
 
-Element.prototype.free = function() {
-  var listeners = this._slisteners = this._slisteners || [];
+Element.prototype.free = function () {
+  var listeners = (this._slisteners = this._slisteners || []);
   for (var i = 0; i < listeners.length; i++) {
     var listener = listeners[i];
     this.screen.removeListener(listener.type, listener.handler);
@@ -305,86 +319,88 @@ Element.prototype.free = function() {
   delete this._slisteners;
 };
 
-Element.prototype.hide = function() {
+Element.prototype.hide = function () {
   if (this.hidden) return;
   this.clearPos();
   this.hidden = true;
-  this.emit('hide');
+  this.emit("hide");
   if (this.screen.focused === this) {
     this.screen.rewindFocus();
   }
 };
 
-Element.prototype.show = function() {
+Element.prototype.show = function () {
   if (!this.hidden) return;
   this.hidden = false;
-  this.emit('show');
+  this.emit("show");
 };
 
-Element.prototype.toggle = function() {
+Element.prototype.toggle = function () {
   return this.hidden ? this.show() : this.hide();
 };
 
-Element.prototype.focus = function() {
-  return this.screen.focused = this;
+Element.prototype.focus = function () {
+  return (this.screen.focused = this);
 };
 
-Element.prototype.setContent = function(content, noClear, noTags) {
+Element.prototype.setContent = function (content, noClear, noTags) {
   if (!noClear) this.clearPos();
-  this.content = content || '';
+  this.content = content || "";
   this.parseContent(noTags);
-  this.emit('set content');
+  this.emit("set content");
 };
 
-Element.prototype.getContent = function() {
-  if (!this._clines) return '';
-  return this._clines.fake.join('\n');
+Element.prototype.getContent = function () {
+  if (!this._clines) return "";
+  return this._clines.fake.join("\n");
 };
 
-Element.prototype.setText = function(content, noClear) {
-  content = content || '';
-  content = content.replace(/\x1b\[[\d;]*m/g, '');
+Element.prototype.setText = function (content, noClear) {
+  content = content || "";
+  content = content.replace(/\x1b\[[\d;]*m/g, "");
   return this.setContent(content, noClear, true);
 };
 
-Element.prototype.getText = function() {
-  return this.getContent().replace(/\x1b\[[\d;]*m/g, '');
+Element.prototype.getText = function () {
+  return this.getContent().replace(/\x1b\[[\d;]*m/g, "");
 };
 
-Element.prototype.parseContent = function(noTags) {
+Element.prototype.parseContent = function (noTags) {
   if (this.detached) return false;
 
   var width = this.width - this.iwidth;
-  if (this._clines == null
-      || this._clines.width !== width
-      || this._clines.content !== this.content) {
+  if (
+    this._clines == null ||
+    this._clines.width !== width ||
+    this._clines.content !== this.content
+  ) {
     var content = this.content;
 
     content = content
-      .replace(/[\x00-\x08\x0b-\x0c\x0e-\x1a\x1c-\x1f\x7f]/g, '')
-      .replace(/\x1b(?!\[[\d;]*m)/g, '')
-      .replace(/\r\n|\r/g, '\n')
+      .replace(/[\x00-\x08\x0b-\x0c\x0e-\x1a\x1c-\x1f\x7f]/g, "")
+      .replace(/\x1b(?!\[[\d;]*m)/g, "")
+      .replace(/\r\n|\r/g, "\n")
       .replace(/\t/g, this.screen.tabc);
 
     if (this.screen.fullUnicode) {
       // double-width chars will eat the next char after render. create a
       // blank character after it so it doesn't eat the real next char.
-      content = content.replace(unicode.chars.all, '$1\x03');
+      content = content.replace(unicode.chars.all, "$1\x03");
       // iTerm2 cannot render combining characters properly.
       if (this.screen.program.isiTerm2) {
-        content = content.replace(unicode.chars.combining, '');
+        content = content.replace(unicode.chars.combining, "");
       }
     } else {
       // no double-width: replace them with question-marks.
-      content = content.replace(unicode.chars.all, '??');
+      content = content.replace(unicode.chars.all, "??");
       // delete combining characters since they're 0-width anyway.
       // NOTE: We could drop this, the non-surrogates would get changed to ? by
       // the unicode filter, and surrogates changed to ? by the surrogate
       // regex. however, the user might expect them to be 0-width.
       // NOTE: Might be better for performance to drop!
-      content = content.replace(unicode.chars.combining, '');
+      content = content.replace(unicode.chars.combining, "");
       // no surrogate pairs: replace them with question-marks.
-      content = content.replace(unicode.chars.surrogate, '?');
+      content = content.replace(unicode.chars.surrogate, "?");
       // XXX Deduplicate code here:
       // content = helpers.dropUnicode(content);
     }
@@ -398,13 +414,16 @@ Element.prototype.parseContent = function(noTags) {
     this._clines.content = this.content;
     this._clines.attr = this._parseAttr(this._clines);
     this._clines.ci = [];
-    this._clines.reduce(function(total, line) {
-      this._clines.ci.push(total);
-      return total + line.length + 1;
-    }.bind(this), 0);
+    this._clines.reduce(
+      function (total, line) {
+        this._clines.ci.push(total);
+        return total + line.length + 1;
+      }.bind(this),
+      0
+    );
 
-    this._pcontent = this._clines.join('\n');
-    this.emit('parsed content');
+    this._pcontent = this._clines.join("\n");
+    this.emit("parsed content");
 
     return true;
   }
@@ -416,21 +435,21 @@ Element.prototype.parseContent = function(noTags) {
 };
 
 // Convert `{red-fg}foo{/red-fg}` to `\x1b[31mfoo\x1b[39m`.
-Element.prototype._parseTags = function(text) {
+Element.prototype._parseTags = function (text) {
   if (!this.parseTags) return text;
   if (!/{\/?[\w\-,;!#]*}/.test(text)) return text;
 
-  var program = this.screen.program
-    , out = ''
-    , state
-    , bg = []
-    , fg = []
-    , flag = []
-    , cap
-    , slash
-    , param
-    , attr
-    , esc;
+  var program = this.screen.program,
+    out = "",
+    state,
+    bg = [],
+    fg = [],
+    flag = [],
+    cap,
+    slash,
+    param,
+    attr,
+    esc;
 
   for (;;) {
     if (!esc && (cap = /^{escape}/.exec(text))) {
@@ -452,26 +471,26 @@ Element.prototype._parseTags = function(text) {
       break;
     }
 
-    if (cap = /^{(\/?)([\w\-,;!#]*)}/.exec(text)) {
+    if ((cap = /^{(\/?)([\w\-,;!#]*)}/.exec(text))) {
       text = text.substring(cap[0].length);
-      slash = cap[1] === '/';
-      param = cap[2].replace(/-/g, ' ');
+      slash = cap[1] === "/";
+      param = cap[2].replace(/-/g, " ");
 
-      if (param === 'open') {
-        out += '{';
+      if (param === "open") {
+        out += "{";
         continue;
-      } else if (param === 'close') {
-        out += '}';
+      } else if (param === "close") {
+        out += "}";
         continue;
       }
 
-      if (param.slice(-3) === ' bg') state = bg;
-      else if (param.slice(-3) === ' fg') state = fg;
+      if (param.slice(-3) === " bg") state = bg;
+      else if (param.slice(-3) === " fg") state = fg;
       else state = flag;
 
       if (slash) {
         if (!param) {
-          out += program._attr('normal');
+          out += program._attr("normal");
           bg.length = 0;
           fg.length = 0;
           flag.length = 0;
@@ -508,7 +527,7 @@ Element.prototype._parseTags = function(text) {
       continue;
     }
 
-    if (cap = /^[\s\S]+?(?={\/?[\w\-,;!#]*})/.exec(text)) {
+    if ((cap = /^[\s\S]+?(?={\/?[\w\-,;!#]*})/.exec(text))) {
       text = text.substring(cap[0].length);
       out += cap[0];
       continue;
@@ -521,14 +540,14 @@ Element.prototype._parseTags = function(text) {
   return out;
 };
 
-Element.prototype._parseAttr = function(lines) {
-  var dattr = this.sattr(this.style)
-    , attr = dattr
-    , attrs = []
-    , line
-    , i
-    , j
-    , c;
+Element.prototype._parseAttr = function (lines) {
+  var dattr = this.sattr(this.style),
+    attr = dattr,
+    attrs = [],
+    line,
+    i,
+    j,
+    c;
 
   if (lines[0].attr === attr) {
     return;
@@ -538,8 +557,8 @@ Element.prototype._parseAttr = function(lines) {
     line = lines[j];
     attrs[j] = attr;
     for (i = 0; i < line.length; i++) {
-      if (line[i] === '\x1b') {
-        if (c = /^\x1b\[[\d;]*m/.exec(line.substring(i))) {
+      if (line[i] === "\x1b") {
+        if ((c = /^\x1b\[[\d;]*m/.exec(line.substring(i)))) {
           attr = this.screen.attrCode(c[0], attr, dattr);
           i += c[0].length - 1;
         }
@@ -550,13 +569,13 @@ Element.prototype._parseAttr = function(lines) {
   return attrs;
 };
 
-Element.prototype._align = function(line, width, align) {
+Element.prototype._align = function (line, width, align) {
   if (!align) return line;
   //if (!align && !~line.indexOf('{|}')) return line;
 
-  var cline = line.replace(/\x1b\[[\d;]*m/g, '')
-    , len = cline.length
-    , s = width - len;
+  var cline = line.replace(/\x1b\[[\d;]*m/g, ""),
+    len = cline.length,
+    s = width - len;
 
   if (this.shrink) {
     s = 0;
@@ -565,43 +584,43 @@ Element.prototype._align = function(line, width, align) {
   if (len === 0) return line;
   if (s < 0) return line;
 
-  if (align === 'center') {
-    s = Array(((s / 2) | 0) + 1).join(' ');
+  if (align === "center") {
+    s = Array(((s / 2) | 0) + 1).join(" ");
     return s + line + s;
-  } else if (align === 'right') {
-    s = Array(s + 1).join(' ');
+  } else if (align === "right") {
+    s = Array(s + 1).join(" ");
     return s + line;
-  } else if (this.parseTags && ~line.indexOf('{|}')) {
-    var parts = line.split('{|}');
-    var cparts = cline.split('{|}');
+  } else if (this.parseTags && ~line.indexOf("{|}")) {
+    var parts = line.split("{|}");
+    var cparts = cline.split("{|}");
     s = Math.max(width - cparts[0].length - cparts[1].length, 0);
-    s = Array(s + 1).join(' ');
+    s = Array(s + 1).join(" ");
     return parts[0] + s + parts[1];
   }
 
   return line;
 };
 
-Element.prototype._wrapContent = function(content, width) {
-  var tags = this.parseTags
-    , state = this.align
-    , wrap = this.wrap
-    , margin = 0
-    , rtof = []
-    , ftor = []
-    , out = []
-    , no = 0
-    , line
-    , align
-    , cap
-    , total
-    , i
-    , part
-    , j
-    , lines
-    , rest;
+Element.prototype._wrapContent = function (content, width) {
+  var tags = this.parseTags,
+    state = this.align,
+    wrap = this.wrap,
+    margin = 0,
+    rtof = [],
+    ftor = [],
+    out = [],
+    no = 0,
+    line,
+    align,
+    cap,
+    total,
+    i,
+    part,
+    j,
+    lines,
+    rest;
 
-  lines = content.split('\n');
+  lines = content.split("\n");
 
   if (!content) {
     out.push(content);
@@ -614,11 +633,10 @@ Element.prototype._wrapContent = function(content, width) {
   }
 
   if (this.scrollbar) margin++;
-  if (this.type === 'textarea') margin++;
+  if (this.type === "textarea") margin++;
   if (width > margin) width -= margin;
 
-main:
-  for (; no < lines.length; no++) {
+  main: for (; no < lines.length; no++) {
     line = lines[no];
     align = state;
 
@@ -626,13 +644,11 @@ main:
 
     // Handle alignment tags.
     if (tags) {
-      if (cap = /^{(left|center|right)}/.exec(line)) {
+      if ((cap = /^{(left|center|right)}/.exec(line))) {
         line = line.substring(cap[0].length);
-        align = state = cap[1] !== 'left'
-          ? cap[1]
-          : null;
+        align = state = cap[1] !== "left" ? cap[1] : null;
       }
-      if (cap = /{\/(left|center|right)}$/.exec(line)) {
+      if ((cap = /{\/(left|center|right)}$/.exec(line))) {
         line = line.slice(0, -cap[0].length);
         //state = null;
         state = this.align;
@@ -643,8 +659,8 @@ main:
     while (line.length > width) {
       // Measure the real width of the string.
       for (i = 0, total = 0; i < line.length; i++) {
-        while (line[i] === '\x1b') {
-          while (line[i] && line[i++] !== 'm');
+        while (line[i] === "\x1b") {
+          while (line[i] && line[i++] !== "m");
         }
         if (!line[i]) break;
         if (++total === width) {
@@ -653,7 +669,7 @@ main:
           i++;
           if (!wrap) {
             rest = line.substring(i).match(/\x1b\[[^m]*m/g);
-            rest = rest ? rest.join('') : '';
+            rest = rest ? rest.join("") : "";
             out.push(this._align(line.substring(0, i) + rest, width, align));
             ftor[no].push(out.length - 1);
             rtof.push(no);
@@ -663,8 +679,8 @@ main:
             // Try to find a space to break on.
             if (i !== line.length) {
               j = i;
-              while (j > i - 10 && j > 0 && line[--j] !== ' ');
-              if (line[j] === ' ') i = j + 1;
+              while (j > i - 10 && j > 0 && line[--j] !== " ");
+              if (line[j] === " ") i = j + 1;
             }
           } else {
             // Try to find a character to break on.
@@ -687,17 +703,22 @@ main:
               // Break _past_ combining chars.
               while (j > i - 10 && j > 0) {
                 j--;
-                if (line[j] === ' '
-                    || line[j] === '\x03'
-                    || (unicode.isSurrogate(line, j - 1) && line[j + 1] !== '\x03')
-                    || unicode.isCombining(line, j)) {
+                if (
+                  line[j] === " " ||
+                  line[j] === "\x03" ||
+                  (unicode.isSurrogate(line, j - 1) &&
+                    line[j + 1] !== "\x03") ||
+                  unicode.isCombining(line, j)
+                ) {
                   break;
                 }
               }
-              if (line[j] === ' '
-                  || line[j] === '\x03'
-                  || (unicode.isSurrogate(line, j - 1) && line[j + 1] !== '\x03')
-                  || unicode.isCombining(line, j)) {
+              if (
+                line[j] === " " ||
+                line[j] === "\x03" ||
+                (unicode.isSurrogate(line, j - 1) && line[j + 1] !== "\x03") ||
+                unicode.isCombining(line, j)
+              ) {
                 i = j + 1;
               }
             }
@@ -715,7 +736,7 @@ main:
 
       // Make sure we didn't wrap the line to the very end, otherwise
       // we get a pointless empty line after a newline.
-      if (line === '') continue main;
+      if (line === "") continue main;
 
       // If only an escape code got cut off, at it to `part`.
       if (/^(?:\x1b[\[\d;]*m)+$/.test(line)) {
@@ -734,145 +755,150 @@ main:
   out.fake = lines;
   out.real = out;
 
-  out.mwidth = out.reduce(function(current, line) {
-    line = line.replace(/\x1b\[[\d;]*m/g, '');
-    return line.length > current
-      ? line.length
-      : current;
+  out.mwidth = out.reduce(function (current, line) {
+    line = line.replace(/\x1b\[[\d;]*m/g, "");
+    return line.length > current ? line.length : current;
   }, 0);
 
   return out;
 };
 
-Element.prototype.__defineGetter__('visible', function() {
+Element.prototype.__defineGetter__("visible", function () {
   var el = this;
   do {
     if (el.detached) return false;
     if (el.hidden) return false;
     // if (!el.lpos) return false;
     // if (el.position.width === 0 || el.position.height === 0) return false;
-  } while (el = el.parent);
+  } while ((el = el.parent));
   return true;
 });
 
-Element.prototype.__defineGetter__('_detached', function() {
+Element.prototype.__defineGetter__("_detached", function () {
   var el = this;
   do {
-    if (el.type === 'screen') return false;
+    if (el.type === "screen") return false;
     if (!el.parent) return true;
-  } while (el = el.parent);
+  } while ((el = el.parent));
   return false;
 });
 
-Element.prototype.enableMouse = function() {
+Element.prototype.enableMouse = function () {
   this.screen._listenMouse(this);
 };
 
-Element.prototype.enableKeys = function() {
+Element.prototype.enableKeys = function () {
   this.screen._listenKeys(this);
 };
 
-Element.prototype.enableInput = function() {
+Element.prototype.enableInput = function () {
   this.screen._listenMouse(this);
   this.screen._listenKeys(this);
 };
 
-Element.prototype.__defineGetter__('draggable', function() {
+Element.prototype.__defineGetter__("draggable", function () {
   return this._draggable === true;
 });
 
-Element.prototype.__defineSetter__('draggable', function(draggable) {
+Element.prototype.__defineSetter__("draggable", function (draggable) {
   return draggable ? this.enableDrag(draggable) : this.disableDrag();
 });
 
-Element.prototype.enableDrag = function(verify) {
+Element.prototype.enableDrag = function (verify) {
   var self = this;
 
   if (this._draggable) return true;
 
-  if (typeof verify !== 'function') {
-    verify = function() { return true; };
+  if (typeof verify !== "function") {
+    verify = function () {
+      return true;
+    };
   }
 
   this.enableMouse();
 
-  this.on('mousedown', this._dragMD = function(data) {
-    if (self.screen._dragging) return;
-    if (!verify(data)) return;
-    self.screen._dragging = self;
-    self._drag = {
-      x: data.x - self.aleft,
-      y: data.y - self.atop
-    };
-    self.setFront();
-  });
+  this.on(
+    "mousedown",
+    (this._dragMD = function (data) {
+      if (self.screen._dragging) return;
+      if (!verify(data)) return;
+      self.screen._dragging = self;
+      self._drag = {
+        x: data.x - self.aleft,
+        y: data.y - self.atop,
+      };
+      self.setFront();
+    })
+  );
 
-  this.onScreenEvent('mouse', this._dragM = function(data) {
-    if (self.screen._dragging !== self) return;
+  this.onScreenEvent(
+    "mouse",
+    (this._dragM = function (data) {
+      if (self.screen._dragging !== self) return;
 
-    if (data.action !== 'mousedown' && data.action !== 'mousemove') {
-      delete self.screen._dragging;
-      delete self._drag;
-      return;
-    }
-
-    // This can happen in edge cases where the user is
-    // already dragging and element when it is detached.
-    if (!self.parent) return;
-
-    var ox = self._drag.x
-      , oy = self._drag.y
-      , px = self.parent.aleft
-      , py = self.parent.atop
-      , x = data.x - px - ox
-      , y = data.y - py - oy;
-
-    if (self.position.right != null) {
-      if (self.position.left != null) {
-        self.width = '100%-' + (self.parent.width - self.width);
+      if (data.action !== "mousedown" && data.action !== "mousemove") {
+        delete self.screen._dragging;
+        delete self._drag;
+        return;
       }
-      self.position.right = null;
-    }
 
-    if (self.position.bottom != null) {
-      if (self.position.top != null) {
-        self.height = '100%-' + (self.parent.height - self.height);
+      // This can happen in edge cases where the user is
+      // already dragging and element when it is detached.
+      if (!self.parent) return;
+
+      var ox = self._drag.x,
+        oy = self._drag.y,
+        px = self.parent.aleft,
+        py = self.parent.atop,
+        x = data.x - px - ox,
+        y = data.y - py - oy;
+
+      if (self.position.right != null) {
+        if (self.position.left != null) {
+          self.width = "100%-" + (self.parent.width - self.width);
+        }
+        self.position.right = null;
       }
-      self.position.bottom = null;
-    }
 
-    self.rleft = x;
-    self.rtop = y;
+      if (self.position.bottom != null) {
+        if (self.position.top != null) {
+          self.height = "100%-" + (self.parent.height - self.height);
+        }
+        self.position.bottom = null;
+      }
 
-    self.screen.render();
-  });
+      self.rleft = x;
+      self.rtop = y;
 
-  return this._draggable = true;
+      self.screen.render();
+    })
+  );
+
+  return (this._draggable = true);
 };
 
-Element.prototype.disableDrag = function() {
+Element.prototype.disableDrag = function () {
   if (!this._draggable) return false;
   delete this.screen._dragging;
   delete this._drag;
-  this.removeListener('mousedown', this._dragMD);
-  this.removeScreenEvent('mouse', this._dragM);
-  return this._draggable = false;
+  this.removeListener("mousedown", this._dragMD);
+  this.removeScreenEvent("mouse", this._dragM);
+  return (this._draggable = false);
 };
 
-Element.prototype.key = function() {
+Element.prototype.key = function () {
   return this.screen.program.key.apply(this, arguments);
 };
 
-Element.prototype.onceKey = function() {
+Element.prototype.onceKey = function () {
   return this.screen.program.onceKey.apply(this, arguments);
 };
 
-Element.prototype.unkey =
-Element.prototype.removeKey = function() {
+Element.prototype.unkey = Element.prototype.removeKey = function () {
   return this.screen.program.unkey.apply(this, arguments);
 };
 
-Element.prototype.setIndex = function(index) {
+Element.prototype.setIndex = function (index) {
   if (!this.parent) return;
 
   if (index < 0) {
@@ -889,35 +915,32 @@ Element.prototype.setIndex = function(index) {
   this.parent.children.splice(index, 0, item);
 };
 
-Element.prototype.setFront = function() {
+Element.prototype.setFront = function () {
   return this.setIndex(-1);
 };
 
-Element.prototype.setBack = function() {
+Element.prototype.setBack = function () {
   return this.setIndex(0);
 };
 
-Element.prototype.clearPos = function(get, override) {
+Element.prototype.clearPos = function (get, override) {
   if (this.detached) return;
   var lpos = this._getCoords(get);
   if (!lpos) return;
-  this.screen.clearRegion(
-    lpos.xi, lpos.xl,
-    lpos.yi, lpos.yl,
-    override);
+  this.screen.clearRegion(lpos.xi, lpos.xl, lpos.yi, lpos.yl, override);
 };
 
-Element.prototype.setLabel = function(options) {
+Element.prototype.setLabel = function (options) {
   var self = this;
-  var Box = require('./box');
+  var Box = require("./box");
 
-  if (typeof options === 'string') {
+  if (typeof options === "string") {
     options = { text: options };
   }
 
   if (this._label) {
     this._label.setContent(options.text);
-    if (options.side !== 'right') {
+    if (options.side !== "right") {
       this._label.rleft = 2 + (this.border ? -1 : 0);
       this._label.position.right = undefined;
       if (!this.screen.autoPadding) {
@@ -940,10 +963,10 @@ Element.prototype.setLabel = function(options) {
     top: -this.itop,
     tags: this.parseTags,
     shrink: true,
-    style: this.style.label
+    style: this.style.label,
   });
 
-  if (options.side !== 'right') {
+  if (options.side !== "right") {
     this._label.rleft = 2 - this.ileft;
   } else {
     this._label.rright = 2 - this.iright;
@@ -952,7 +975,7 @@ Element.prototype.setLabel = function(options) {
   this._label._isLabel = true;
 
   if (!this.screen.autoPadding) {
-    if (options.side !== 'right') {
+    if (options.side !== "right") {
       this._label.rleft = 2;
     } else {
       this._label.rright = 2;
@@ -960,37 +983,43 @@ Element.prototype.setLabel = function(options) {
     this._label.rtop = 0;
   }
 
-  var reposition = function() {
+  var reposition = function () {
     self._label.rtop = (self.childBase || 0) - self.itop;
     if (!self.screen.autoPadding) {
-      self._label.rtop = (self.childBase || 0);
+      self._label.rtop = self.childBase || 0;
     }
     self.screen.render();
   };
 
-  this.on('scroll', this._labelScroll = function() {
-    reposition();
-  });
-
-  this.on('resize', this._labelResize = function() {
-    nextTick(function() {
+  this.on(
+    "scroll",
+    (this._labelScroll = function () {
       reposition();
-    });
-  });
+    })
+  );
+
+  this.on(
+    "resize",
+    (this._labelResize = function () {
+      nextTick(function () {
+        reposition();
+      });
+    })
+  );
 };
 
-Element.prototype.removeLabel = function() {
+Element.prototype.removeLabel = function () {
   if (!this._label) return;
-  this.removeListener('scroll', this._labelScroll);
-  this.removeListener('resize', this._labelResize);
+  this.removeListener("scroll", this._labelScroll);
+  this.removeListener("resize", this._labelResize);
   this._label.detach();
   delete this._labelScroll;
   delete this._labelResize;
   delete this._label;
 };
 
-Element.prototype.setHover = function(options) {
-  if (typeof options === 'string') {
+Element.prototype.setHover = function (options) {
+  if (typeof options === "string") {
     options = { text: options };
   }
 
@@ -999,7 +1028,7 @@ Element.prototype.setHover = function(options) {
   this.screen._initHover();
 };
 
-Element.prototype.removeHover = function() {
+Element.prototype.removeHover = function () {
   delete this._hoverOptions;
   if (!this.screen._hoverText || this.screen._hoverText.detached) return;
   this.screen._hoverText.detach();
@@ -1025,7 +1054,7 @@ Element.prototype.removeHover = function() {
 // position (since that might be wrong because
 // it doesn't handle content shrinkage).
 
-Element.prototype._getPos = function() {
+Element.prototype._getPos = function () {
   var pos = this.lpos;
 
   assert.ok(pos);
@@ -1046,18 +1075,18 @@ Element.prototype._getPos = function() {
  * Position Getters
  */
 
-Element.prototype._getWidth = function(get) {
-  var parent = get ? this.parent._getPos() : this.parent
-    , width = this.position.width
-    , left
-    , expr;
+Element.prototype._getWidth = function (get) {
+  var parent = get ? this.parent._getPos() : this.parent,
+    width = this.position.width,
+    left,
+    expr;
 
-  if (typeof width === 'string') {
-    if (width === 'half') width = '50%';
+  if (typeof width === "string") {
+    if (width === "half") width = "50%";
     expr = width.split(/(?=\+|-)/);
     width = expr[0];
     width = +width.slice(0, -1) / 100;
-    width = parent.width * width | 0;
+    width = (parent.width * width) | 0;
     width += +(expr[1] || 0);
     return width;
   }
@@ -1070,18 +1099,20 @@ Element.prototype._getWidth = function(get) {
   // calculated here.
   if (width == null) {
     left = this.position.left || 0;
-    if (typeof left === 'string') {
-      if (left === 'center') left = '50%';
+    if (typeof left === "string") {
+      if (left === "center") left = "50%";
       expr = left.split(/(?=\+|-)/);
       left = expr[0];
       left = +left.slice(0, -1) / 100;
-      left = parent.width * left | 0;
+      left = (parent.width * left) | 0;
       left += +(expr[1] || 0);
     }
     width = parent.width - (this.position.right || 0) - left;
     if (this.screen.autoPadding) {
-      if ((this.position.left != null || this.position.right == null)
-          && this.position.left !== 'center') {
+      if (
+        (this.position.left != null || this.position.right == null) &&
+        this.position.left !== "center"
+      ) {
         width -= this.parent.ileft;
       }
       width -= this.parent.iright;
@@ -1091,22 +1122,22 @@ Element.prototype._getWidth = function(get) {
   return width;
 };
 
-Element.prototype.__defineGetter__('width', function() {
+Element.prototype.__defineGetter__("width", function () {
   return this._getWidth(false);
 });
 
-Element.prototype._getHeight = function(get) {
-  var parent = get ? this.parent._getPos() : this.parent
-    , height = this.position.height
-    , top
-    , expr;
+Element.prototype._getHeight = function (get) {
+  var parent = get ? this.parent._getPos() : this.parent,
+    height = this.position.height,
+    top,
+    expr;
 
-  if (typeof height === 'string') {
-    if (height === 'half') height = '50%';
+  if (typeof height === "string") {
+    if (height === "half") height = "50%";
     expr = height.split(/(?=\+|-)/);
     height = expr[0];
     height = +height.slice(0, -1) / 100;
-    height = parent.height * height | 0;
+    height = (parent.height * height) | 0;
     height += +(expr[1] || 0);
     return height;
   }
@@ -1119,19 +1150,20 @@ Element.prototype._getHeight = function(get) {
   // calculated here.
   if (height == null) {
     top = this.position.top || 0;
-    if (typeof top === 'string') {
-      if (top === 'center') top = '50%';
+    if (typeof top === "string") {
+      if (top === "center") top = "50%";
       expr = top.split(/(?=\+|-)/);
       top = expr[0];
       top = +top.slice(0, -1) / 100;
-      top = parent.height * top | 0;
+      top = (parent.height * top) | 0;
       top += +(expr[1] || 0);
     }
     height = parent.height - (this.position.bottom || 0) - top;
     if (this.screen.autoPadding) {
-      if ((this.position.top != null
-          || this.position.bottom == null)
-          && this.position.top !== 'center') {
+      if (
+        (this.position.top != null || this.position.bottom == null) &&
+        this.position.top !== "center"
+      ) {
         height -= this.parent.itop;
       }
       height -= this.parent.ibottom;
@@ -1141,24 +1173,24 @@ Element.prototype._getHeight = function(get) {
   return height;
 };
 
-Element.prototype.__defineGetter__('height', function() {
+Element.prototype.__defineGetter__("height", function () {
   return this._getHeight(false);
 });
 
-Element.prototype._getLeft = function(get) {
-  var parent = get ? this.parent._getPos() : this.parent
-    , left = this.position.left || 0
-    , expr;
+Element.prototype._getLeft = function (get) {
+  var parent = get ? this.parent._getPos() : this.parent,
+    left = this.position.left || 0,
+    expr;
 
-  if (typeof left === 'string') {
-    if (left === 'center') left = '50%';
+  if (typeof left === "string") {
+    if (left === "center") left = "50%";
     expr = left.split(/(?=\+|-)/);
     left = expr[0];
     left = +left.slice(0, -1) / 100;
-    left = parent.width * left | 0;
+    left = (parent.width * left) | 0;
     left += +(expr[1] || 0);
-    if (this.position.left === 'center') {
-      left -= this._getWidth(get) / 2 | 0;
+    if (this.position.left === "center") {
+      left -= (this._getWidth(get) / 2) | 0;
     }
   }
 
@@ -1167,9 +1199,10 @@ Element.prototype._getLeft = function(get) {
   }
 
   if (this.screen.autoPadding) {
-    if ((this.position.left != null
-        || this.position.right == null)
-        && this.position.left !== 'center') {
+    if (
+      (this.position.left != null || this.position.right == null) &&
+      this.position.left !== "center"
+    ) {
       left += this.parent.ileft;
     }
   }
@@ -1177,13 +1210,13 @@ Element.prototype._getLeft = function(get) {
   return (parent.aleft || 0) + left;
 };
 
-Element.prototype.__defineGetter__('aleft', function() {
+Element.prototype.__defineGetter__("aleft", function () {
   return this._getLeft(false);
 });
 
-Element.prototype._getRight = function(get) {
-  var parent = get ? this.parent._getPos() : this.parent
-    , right;
+Element.prototype._getRight = function (get) {
+  var parent = get ? this.parent._getPos() : this.parent,
+    right;
 
   if (this.position.right == null && this.position.left != null) {
     right = this.screen.cols - (this._getLeft(get) + this._getWidth(get));
@@ -1202,24 +1235,24 @@ Element.prototype._getRight = function(get) {
   return right;
 };
 
-Element.prototype.__defineGetter__('aright', function() {
+Element.prototype.__defineGetter__("aright", function () {
   return this._getRight(false);
 });
 
-Element.prototype._getTop = function(get) {
-  var parent = get ? this.parent._getPos() : this.parent
-    , top = this.position.top || 0
-    , expr;
+Element.prototype._getTop = function (get) {
+  var parent = get ? this.parent._getPos() : this.parent,
+    top = this.position.top || 0,
+    expr;
 
-  if (typeof top === 'string') {
-    if (top === 'center') top = '50%';
+  if (typeof top === "string") {
+    if (top === "center") top = "50%";
     expr = top.split(/(?=\+|-)/);
     top = expr[0];
     top = +top.slice(0, -1) / 100;
-    top = parent.height * top | 0;
+    top = (parent.height * top) | 0;
     top += +(expr[1] || 0);
-    if (this.position.top === 'center') {
-      top -= this._getHeight(get) / 2 | 0;
+    if (this.position.top === "center") {
+      top -= (this._getHeight(get) / 2) | 0;
     }
   }
 
@@ -1228,9 +1261,10 @@ Element.prototype._getTop = function(get) {
   }
 
   if (this.screen.autoPadding) {
-    if ((this.position.top != null
-        || this.position.bottom == null)
-        && this.position.top !== 'center') {
+    if (
+      (this.position.top != null || this.position.bottom == null) &&
+      this.position.top !== "center"
+    ) {
       top += this.parent.itop;
     }
   }
@@ -1238,13 +1272,13 @@ Element.prototype._getTop = function(get) {
   return (parent.atop || 0) + top;
 };
 
-Element.prototype.__defineGetter__('atop', function() {
+Element.prototype.__defineGetter__("atop", function () {
   return this._getTop(false);
 });
 
-Element.prototype._getBottom = function(get) {
-  var parent = get ? this.parent._getPos() : this.parent
-    , bottom;
+Element.prototype._getBottom = function (get) {
+  var parent = get ? this.parent._getPos() : this.parent,
+    bottom;
 
   if (this.position.bottom == null && this.position.top != null) {
     bottom = this.screen.rows - (this._getTop(get) + this._getHeight(get));
@@ -1263,23 +1297,23 @@ Element.prototype._getBottom = function(get) {
   return bottom;
 };
 
-Element.prototype.__defineGetter__('abottom', function() {
+Element.prototype.__defineGetter__("abottom", function () {
   return this._getBottom(false);
 });
 
-Element.prototype.__defineGetter__('rleft', function() {
+Element.prototype.__defineGetter__("rleft", function () {
   return this.aleft - this.parent.aleft;
 });
 
-Element.prototype.__defineGetter__('rright', function() {
+Element.prototype.__defineGetter__("rright", function () {
   return this.aright - this.parent.aright;
 });
 
-Element.prototype.__defineGetter__('rtop', function() {
+Element.prototype.__defineGetter__("rtop", function () {
   return this.atop - this.parent.atop;
 });
 
-Element.prototype.__defineGetter__('rbottom', function() {
+Element.prototype.__defineGetter__("rbottom", function () {
   return this.abottom - this.parent.abottom;
 });
 
@@ -1292,195 +1326,205 @@ Element.prototype.__defineGetter__('rbottom', function() {
 // If position.bottom is null, we could simply set top instead.
 // But it wouldn't replicate bottom behavior appropriately if
 // the parent was resized, etc.
-Element.prototype.__defineSetter__('width', function(val) {
+Element.prototype.__defineSetter__("width", function (val) {
   if (this.position.width === val) return;
   if (/^\d+$/.test(val)) val = +val;
-  this.emit('resize');
+  this.emit("resize");
   this.clearPos();
-  return this.position.width = val;
+  return (this.position.width = val);
 });
 
-Element.prototype.__defineSetter__('height', function(val) {
+Element.prototype.__defineSetter__("height", function (val) {
   if (this.position.height === val) return;
   if (/^\d+$/.test(val)) val = +val;
-  this.emit('resize');
+  this.emit("resize");
   this.clearPos();
-  return this.position.height = val;
+  return (this.position.height = val);
 });
 
-Element.prototype.__defineSetter__('aleft', function(val) {
+Element.prototype.__defineSetter__("aleft", function (val) {
   var expr;
-  if (typeof val === 'string') {
-    if (val === 'center') {
-      val = this.screen.width / 2 | 0;
-      val -= this.width / 2 | 0;
+  if (typeof val === "string") {
+    if (val === "center") {
+      val = (this.screen.width / 2) | 0;
+      val -= (this.width / 2) | 0;
     } else {
       expr = val.split(/(?=\+|-)/);
       val = expr[0];
       val = +val.slice(0, -1) / 100;
-      val = this.screen.width * val | 0;
+      val = (this.screen.width * val) | 0;
       val += +(expr[1] || 0);
     }
   }
   val -= this.parent.aleft;
   if (this.position.left === val) return;
-  this.emit('move');
+  this.emit("move");
   this.clearPos();
-  return this.position.left = val;
+  return (this.position.left = val);
 });
 
-Element.prototype.__defineSetter__('aright', function(val) {
+Element.prototype.__defineSetter__("aright", function (val) {
   val -= this.parent.aright;
   if (this.position.right === val) return;
-  this.emit('move');
+  this.emit("move");
   this.clearPos();
-  return this.position.right = val;
+  return (this.position.right = val);
 });
 
-Element.prototype.__defineSetter__('atop', function(val) {
+Element.prototype.__defineSetter__("atop", function (val) {
   var expr;
-  if (typeof val === 'string') {
-    if (val === 'center') {
-      val = this.screen.height / 2 | 0;
-      val -= this.height / 2 | 0;
+  if (typeof val === "string") {
+    if (val === "center") {
+      val = (this.screen.height / 2) | 0;
+      val -= (this.height / 2) | 0;
     } else {
       expr = val.split(/(?=\+|-)/);
       val = expr[0];
       val = +val.slice(0, -1) / 100;
-      val = this.screen.height * val | 0;
+      val = (this.screen.height * val) | 0;
       val += +(expr[1] || 0);
     }
   }
   val -= this.parent.atop;
   if (this.position.top === val) return;
-  this.emit('move');
+  this.emit("move");
   this.clearPos();
-  return this.position.top = val;
+  return (this.position.top = val);
 });
 
-Element.prototype.__defineSetter__('abottom', function(val) {
+Element.prototype.__defineSetter__("abottom", function (val) {
   val -= this.parent.abottom;
   if (this.position.bottom === val) return;
-  this.emit('move');
+  this.emit("move");
   this.clearPos();
-  return this.position.bottom = val;
+  return (this.position.bottom = val);
 });
 
-Element.prototype.__defineSetter__('rleft', function(val) {
+Element.prototype.__defineSetter__("rleft", function (val) {
   if (this.position.left === val) return;
   if (/^\d+$/.test(val)) val = +val;
-  this.emit('move');
+  this.emit("move");
   this.clearPos();
-  return this.position.left = val;
+  return (this.position.left = val);
 });
 
-Element.prototype.__defineSetter__('rright', function(val) {
+Element.prototype.__defineSetter__("rright", function (val) {
   if (this.position.right === val) return;
-  this.emit('move');
+  this.emit("move");
   this.clearPos();
-  return this.position.right = val;
+  return (this.position.right = val);
 });
 
-Element.prototype.__defineSetter__('rtop', function(val) {
+Element.prototype.__defineSetter__("rtop", function (val) {
   if (this.position.top === val) return;
   if (/^\d+$/.test(val)) val = +val;
-  this.emit('move');
+  this.emit("move");
   this.clearPos();
-  return this.position.top = val;
+  return (this.position.top = val);
 });
 
-Element.prototype.__defineSetter__('rbottom', function(val) {
+Element.prototype.__defineSetter__("rbottom", function (val) {
   if (this.position.bottom === val) return;
-  this.emit('move');
+  this.emit("move");
   this.clearPos();
-  return this.position.bottom = val;
+  return (this.position.bottom = val);
 });
 
-Element.prototype.__defineGetter__('ileft', function() {
+Element.prototype.__defineGetter__("ileft", function () {
   return (this.border ? 1 : 0) + this.padding.left;
   // return (this.border && this.border.left ? 1 : 0) + this.padding.left;
 });
 
-Element.prototype.__defineGetter__('itop', function() {
+Element.prototype.__defineGetter__("itop", function () {
   return (this.border ? 1 : 0) + this.padding.top;
   // return (this.border && this.border.top ? 1 : 0) + this.padding.top;
 });
 
-Element.prototype.__defineGetter__('iright', function() {
+Element.prototype.__defineGetter__("iright", function () {
   return (this.border ? 1 : 0) + this.padding.right;
   // return (this.border && this.border.right ? 1 : 0) + this.padding.right;
 });
 
-Element.prototype.__defineGetter__('ibottom', function() {
+Element.prototype.__defineGetter__("ibottom", function () {
   return (this.border ? 1 : 0) + this.padding.bottom;
   // return (this.border && this.border.bottom ? 1 : 0) + this.padding.bottom;
 });
 
-Element.prototype.__defineGetter__('iwidth', function() {
+Element.prototype.__defineGetter__("iwidth", function () {
   // return (this.border
   //   ? ((this.border.left ? 1 : 0) + (this.border.right ? 1 : 0)) : 0)
   //   + this.padding.left + this.padding.right;
   return (this.border ? 2 : 0) + this.padding.left + this.padding.right;
 });
 
-Element.prototype.__defineGetter__('iheight', function() {
+Element.prototype.__defineGetter__("iheight", function () {
   // return (this.border
   //   ? ((this.border.top ? 1 : 0) + (this.border.bottom ? 1 : 0)) : 0)
   //   + this.padding.top + this.padding.bottom;
   return (this.border ? 2 : 0) + this.padding.top + this.padding.bottom;
 });
 
-Element.prototype.__defineGetter__('tpadding', function() {
-  return this.padding.left + this.padding.top
-    + this.padding.right + this.padding.bottom;
+Element.prototype.__defineGetter__("tpadding", function () {
+  return (
+    this.padding.left +
+    this.padding.top +
+    this.padding.right +
+    this.padding.bottom
+  );
 });
 
 /**
  * Relative coordinates as default properties
  */
 
-Element.prototype.__defineGetter__('left', function() {
+Element.prototype.__defineGetter__("left", function () {
   return this.rleft;
 });
 
-Element.prototype.__defineGetter__('right', function() {
+Element.prototype.__defineGetter__("right", function () {
   return this.rright;
 });
 
-Element.prototype.__defineGetter__('top', function() {
+Element.prototype.__defineGetter__("top", function () {
   return this.rtop;
 });
 
-Element.prototype.__defineGetter__('bottom', function() {
+Element.prototype.__defineGetter__("bottom", function () {
   return this.rbottom;
 });
 
-Element.prototype.__defineSetter__('left', function(val) {
-  return this.rleft = val;
+Element.prototype.__defineSetter__("left", function (val) {
+  return (this.rleft = val);
 });
 
-Element.prototype.__defineSetter__('right', function(val) {
-  return this.rright = val;
+Element.prototype.__defineSetter__("right", function (val) {
+  return (this.rright = val);
 });
 
-Element.prototype.__defineSetter__('top', function(val) {
-  return this.rtop = val;
+Element.prototype.__defineSetter__("top", function (val) {
+  return (this.rtop = val);
 });
 
-Element.prototype.__defineSetter__('bottom', function(val) {
-  return this.rbottom = val;
+Element.prototype.__defineSetter__("bottom", function (val) {
+  return (this.rbottom = val);
 });
 
 /**
  * Rendering - here be dragons
  */
 
-Element.prototype._getShrinkBox = function(xi, xl, yi, yl, get) {
+Element.prototype._getShrinkBox = function (xi, xl, yi, yl, get) {
   if (!this.children.length) {
     return { xi: xi, xl: xi + 1, yi: yi, yl: yi + 1 };
   }
 
-  var i, el, ret, mxi = xi, mxl = xi + 1, myi = yi, myl = yi + 1;
+  var i,
+    el,
+    ret,
+    mxi = xi,
+    mxl = xi + 1,
+    myi = yi,
+    myl = yi + 1;
 
   // This is a chicken and egg problem. We need to determine how the children
   // will render in order to determine how this element renders, but it in
@@ -1540,9 +1584,10 @@ Element.prototype._getShrinkBox = function(xi, xl, yi, yl, get) {
     //this.shrink = true;
   }
 
-  if (this.position.width == null
-      && (this.position.left == null
-      || this.position.right == null)) {
+  if (
+    this.position.width == null &&
+    (this.position.left == null || this.position.right == null)
+  ) {
     if (this.position.left == null && this.position.right != null) {
       xi = xl - (mxl - mxi);
       if (!this.screen.autoPadding) {
@@ -1559,7 +1604,7 @@ Element.prototype._getShrinkBox = function(xi, xl, yi, yl, get) {
         // XXX Maybe just to this for all this being that this would affect
         // width shrunken normal shrunken lists as well.
         // if (this._isList) {
-        if (this.type === 'list-table') {
+        if (this.type === "list-table") {
           xl -= this.padding.left + this.padding.right;
           xl += this.iright;
         }
@@ -1570,10 +1615,11 @@ Element.prototype._getShrinkBox = function(xi, xl, yi, yl, get) {
     }
   }
 
-  if (this.position.height == null
-      && (this.position.top == null
-      || this.position.bottom == null)
-      && (!this.scrollable || this._isList)) {
+  if (
+    this.position.height == null &&
+    (this.position.top == null || this.position.bottom == null) &&
+    (!this.scrollable || this._isList)
+  ) {
     // NOTE: Lists get special treatment if they are shrunken - assume they
     // want all list items showing. This is one case we can calculate the
     // height based on items/boxes.
@@ -1601,13 +1647,14 @@ Element.prototype._getShrinkBox = function(xi, xl, yi, yl, get) {
   return { xi: xi, xl: xl, yi: yi, yl: yl };
 };
 
-Element.prototype._getShrinkContent = function(xi, xl, yi, yl) {
-  var h = this._clines.length
-    , w = this._clines.mwidth || 1;
+Element.prototype._getShrinkContent = function (xi, xl, yi, yl) {
+  var h = this._clines.length,
+    w = this._clines.mwidth || 1;
 
-  if (this.position.width == null
-      && (this.position.left == null
-      || this.position.right == null)) {
+  if (
+    this.position.width == null &&
+    (this.position.left == null || this.position.right == null)
+  ) {
     if (this.position.left == null && this.position.right != null) {
       xi = xl - w - this.iwidth;
     } else {
@@ -1615,10 +1662,11 @@ Element.prototype._getShrinkContent = function(xi, xl, yi, yl) {
     }
   }
 
-  if (this.position.height == null
-      && (this.position.top == null
-      || this.position.bottom == null)
-      && (!this.scrollable || this._isList)) {
+  if (
+    this.position.height == null &&
+    (this.position.top == null || this.position.bottom == null) &&
+    (!this.scrollable || this._isList)
+  ) {
     if (this.position.top == null && this.position.bottom != null) {
       yi = yl - h - this.iheight;
     } else {
@@ -1629,11 +1677,11 @@ Element.prototype._getShrinkContent = function(xi, xl, yi, yl) {
   return { xi: xi, xl: xl, yi: yi, yl: yl };
 };
 
-Element.prototype._getShrink = function(xi, xl, yi, yl, get) {
-  var shrinkBox = this._getShrinkBox(xi, xl, yi, yl, get)
-    , shrinkContent = this._getShrinkContent(xi, xl, yi, yl, get)
-    , xll = xl
-    , yll = yl;
+Element.prototype._getShrink = function (xi, xl, yi, yl, get) {
+  var shrinkBox = this._getShrinkBox(xi, xl, yi, yl, get),
+    shrinkContent = this._getShrinkContent(xi, xl, yi, yl, get),
+    xll = xl,
+    yll = yl;
 
   // Figure out which one is bigger and use it.
   if (shrinkBox.xl - shrinkBox.xi > shrinkContent.xl - shrinkContent.xi) {
@@ -1653,14 +1701,14 @@ Element.prototype._getShrink = function(xi, xl, yi, yl, get) {
   }
 
   // Recenter shrunken elements.
-  if (xl < xll && this.position.left === 'center') {
-    xll = (xll - xl) / 2 | 0;
+  if (xl < xll && this.position.left === "center") {
+    xll = ((xll - xl) / 2) | 0;
     xi += xll;
     xl += xll;
   }
 
-  if (yl < yll && this.position.top === 'center') {
-    yll = (yll - yl) / 2 | 0;
+  if (yl < yll && this.position.top === "center") {
+    yll = ((yll - yl) / 2) | 0;
     yi += yll;
     yl += yll;
   }
@@ -1668,39 +1716,39 @@ Element.prototype._getShrink = function(xi, xl, yi, yl, get) {
   return { xi: xi, xl: xl, yi: yi, yl: yl };
 };
 
-Element.prototype._getCoords = function(get, noscroll) {
+Element.prototype._getCoords = function (get, noscroll) {
   if (this.hidden) return;
 
   // if (this.parent._rendering) {
   //   get = true;
   // }
 
-  var xi = this._getLeft(get)
-    , xl = xi + this._getWidth(get)
-    , yi = this._getTop(get)
-    , yl = yi + this._getHeight(get)
-    , base = this.childBase || 0
-    , el = this
-    , fixed = this.fixed
-    , coords
-    , v
-    , noleft
-    , noright
-    , notop
-    , nobot
-    , ppos
-    , b;
+  var xi = this._getLeft(get),
+    xl = xi + this._getWidth(get),
+    yi = this._getTop(get),
+    yl = yi + this._getHeight(get),
+    base = this.childBase || 0,
+    el = this,
+    fixed = this.fixed,
+    coords,
+    v,
+    noleft,
+    noright,
+    notop,
+    nobot,
+    ppos,
+    b;
 
   // Attempt to shrink the element base on the
   // size of the content and child elements.
   if (this.shrink) {
     coords = this._getShrink(xi, xl, yi, yl, get);
-    xi = coords.xi, xl = coords.xl;
-    yi = coords.yi, yl = coords.yl;
+    (xi = coords.xi), (xl = coords.xl);
+    (yi = coords.yi), (yl = coords.yl);
   }
 
   // Find a scrollable ancestor if we have one.
-  while (el = el.parent) {
+  while ((el = el.parent)) {
     if (el.scrollable) {
       if (fixed) {
         fixed = false;
@@ -1829,12 +1877,12 @@ Element.prototype._getCoords = function(get, noscroll) {
     noright: noright,
     notop: notop,
     nobot: nobot,
-    renders: this.screen.renders
+    renders: this.screen.renders,
   };
 };
 
-Element.prototype.render = function() {
-  this._emit('prerender');
+Element.prototype.render = function () {
+  this._emit("prerender");
 
   this.parseContent();
 
@@ -1854,24 +1902,24 @@ Element.prototype.render = function() {
     return;
   }
 
-  var lines = this.screen.lines
-    , xi = coords.xi
-    , xl = coords.xl
-    , yi = coords.yi
-    , yl = coords.yl
-    , x
-    , y
-    , cell
-    , attr
-    , ch
-    , content = this._pcontent
-    , ci = this._clines.ci[coords.base]
-    , battr
-    , dattr
-    , c
-    , visible
-    , i
-    , bch = this.ch;
+  var lines = this.screen.lines,
+    xi = coords.xi,
+    xl = coords.xl,
+    yi = coords.yi,
+    yl = coords.yl,
+    x,
+    y,
+    cell,
+    attr,
+    ch,
+    content = this._pcontent,
+    ci = this._clines.ci[coords.base],
+    battr,
+    dattr,
+    c,
+    visible,
+    i,
+    bch = this.ch;
 
   // Clip content if it's off the edge of the screen
   // if (xi + this.ileft < 0 || yi + this.itop < 0) {
@@ -1904,7 +1952,7 @@ Element.prototype.render = function() {
 
   this.lpos = coords;
 
-  if (this.border && this.border.type === 'line') {
+  if (this.border && this.border.type === "line") {
     this.screen._borderStops[coords.yi] = true;
     this.screen._borderStops[coords.yl - 1] = true;
     // if (!this.screen._borderStops[coords.yi]) {
@@ -1935,7 +1983,7 @@ Element.prototype.render = function() {
   // content-drawing loop will skip a few cells/lines.
   // To deal with this, we can just fill the whole thing
   // ahead of time. This could be optimized.
-  if (this.tpadding || (this.valign && this.valign !== 'top')) {
+  if (this.tpadding || (this.valign && this.valign !== "top")) {
     if (this.style.transparent) {
       for (y = Math.max(yi, 0); y < yl; y++) {
         if (!lines[y]) break;
@@ -1952,18 +2000,18 @@ Element.prototype.render = function() {
   }
 
   if (this.tpadding) {
-    xi += this.padding.left, xl -= this.padding.right;
-    yi += this.padding.top, yl -= this.padding.bottom;
+    (xi += this.padding.left), (xl -= this.padding.right);
+    (yi += this.padding.top), (yl -= this.padding.bottom);
   }
 
   // Determine where to place the text if it's vertically aligned.
-  if (this.valign === 'middle' || this.valign === 'bottom') {
+  if (this.valign === "middle" || this.valign === "bottom") {
     visible = yl - yi;
     if (this._clines.length < visible) {
-      if (this.valign === 'middle') {
-        visible = visible / 2 | 0;
-        visible -= this._clines.length / 2 | 0;
-      } else if (this.valign === 'bottom') {
+      if (this.valign === "middle") {
+        visible = (visible / 2) | 0;
+        visible -= (this._clines.length / 2) | 0;
+      } else if (this.valign === "bottom") {
         visible -= this._clines.length;
       }
       ci -= visible * (xl - xi);
@@ -1996,14 +2044,17 @@ Element.prototype.render = function() {
       // }
 
       // Handle escape codes.
-      while (ch === '\x1b') {
-        if (c = /^\x1b\[[\d;]*m/.exec(content.substring(ci - 1))) {
+      while (ch === "\x1b") {
+        if ((c = /^\x1b\[[\d;]*m/.exec(content.substring(ci - 1)))) {
           ci += c[0].length - 1;
           attr = this.screen.attrCode(c[0], attr, dattr);
           // Ignore foreground changes for selected items.
-          if (this.parent._isList && this.parent.interactive
-              && this.parent.items[this.parent.selected] === this
-              && this.parent.options.invertSelected !== false) {
+          if (
+            this.parent._isList &&
+            this.parent.interactive &&
+            this.parent.items[this.parent.selected] === this &&
+            this.parent.options.invertSelected !== false
+          ) {
             attr = (attr & ~(0x1ff << 9)) | (dattr & (0x1ff << 9));
           }
           ch = content[ci] || bch;
@@ -2014,12 +2065,12 @@ Element.prototype.render = function() {
       }
 
       // Handle newlines.
-      if (ch === '\t') ch = bch;
-      if (ch === '\n') {
+      if (ch === "\t") ch = bch;
+      if (ch === "\n") {
         // If we're on the first cell and we find a newline and the last cell
         // of the last line was not a newline, let's just treat this like the
         // newline was already "counted".
-        if (x === xi && y !== yi && content[ci - 2] !== '\n') {
+        if (x === xi && y !== yi && content[ci - 2] !== "\n") {
           x--;
           continue;
         }
@@ -2093,7 +2144,7 @@ Element.prototype.render = function() {
     i = Math.max(this._clines.length, this._scrollBottom());
   }
   if (coords.notop || coords.nobot) i = -Infinity;
-  if (this.scrollbar && (yl - yi) < i) {
+  if (this.scrollbar && yl - yi < i) {
     x = xl - 1;
     if (this.scrollbar.ignoreBorder && this.border) x++;
     if (this.alwaysScroll) {
@@ -2101,21 +2152,25 @@ Element.prototype.render = function() {
     } else {
       y = (this.childBase + this.childOffset) / (i - 1);
     }
-    y = yi + ((yl - yi) * y | 0);
+    y = yi + (((yl - yi) * y) | 0);
     if (y >= yl) y = yl - 1;
     cell = lines[y] && lines[y][x];
     if (cell) {
       if (this.track) {
-        ch = this.track.ch || ' ';
-        attr = this.sattr(this.style.track,
+        ch = this.track.ch || " ";
+        attr = this.sattr(
+          this.style.track,
           this.style.track.fg || this.style.fg,
-          this.style.track.bg || this.style.bg);
+          this.style.track.bg || this.style.bg
+        );
         this.screen.fillRegion(attr, ch, x, x + 1, yi, yl);
       }
-      ch = this.scrollbar.ch || ' ';
-      attr = this.sattr(this.style.scrollbar,
+      ch = this.scrollbar.ch || " ";
+      attr = this.sattr(
+        this.style.scrollbar,
         this.style.scrollbar.fg || this.style.fg,
-        this.style.scrollbar.bg || this.style.bg);
+        this.style.scrollbar.bg || this.style.bg
+      );
       if (attr !== cell[0] || ch !== cell[1]) {
         lines[y][x][0] = attr;
         lines[y][x][1] = ch;
@@ -2127,8 +2182,8 @@ Element.prototype.render = function() {
   if (this.border) xi--, xl++, yi--, yl++;
 
   if (this.tpadding) {
-    xi -= this.padding.left, xl += this.padding.right;
-    yi -= this.padding.top, yl += this.padding.bottom;
+    (xi -= this.padding.left), (xl += this.padding.right);
+    (yi -= this.padding.top), (yl += this.padding.bottom);
   }
 
   // Draw the border.
@@ -2142,41 +2197,41 @@ Element.prototype.render = function() {
       if (coords.noright && x === xl - 1) continue;
       cell = lines[y][x];
       if (!cell) continue;
-      if (this.border.type === 'line') {
+      if (this.border.type === "line") {
         if (x === xi) {
-          ch = '\u250c'; // '┌'
+          ch = "\u250c"; // '┌'
           if (!this.border.left) {
             if (this.border.top) {
-              ch = '\u2500'; // '─'
+              ch = "\u2500"; // '─'
             } else {
               continue;
             }
           } else {
             if (!this.border.top) {
-              ch = '\u2502'; // '│'
+              ch = "\u2502"; // '│'
             }
           }
         } else if (x === xl - 1) {
-          ch = '\u2510'; // '┐'
+          ch = "\u2510"; // '┐'
           if (!this.border.right) {
             if (this.border.top) {
-              ch = '\u2500'; // '─'
+              ch = "\u2500"; // '─'
             } else {
               continue;
             }
           } else {
             if (!this.border.top) {
-              ch = '\u2502'; // '│'
+              ch = "\u2502"; // '│'
             }
           }
         } else {
-          ch = '\u2500'; // '─'
+          ch = "\u2500"; // '─'
         }
-      } else if (this.border.type === 'bg') {
+      } else if (this.border.type === "bg") {
         ch = this.border.ch;
       }
       if (!this.border.top && x !== xi && x !== xl - 1) {
-        ch = ' ';
+        ch = " ";
         if (dattr !== cell[0] || ch !== cell[1]) {
           lines[y][x][0] = dattr;
           lines[y][x][1] = ch;
@@ -2196,19 +2251,19 @@ Element.prototype.render = function() {
       cell = lines[y][xi];
       if (cell) {
         if (this.border.left) {
-          if (this.border.type === 'line') {
-            ch = '\u2502'; // '│'
-          } else if (this.border.type === 'bg') {
+          if (this.border.type === "line") {
+            ch = "\u2502"; // '│'
+          } else if (this.border.type === "bg") {
             ch = this.border.ch;
           }
           if (!coords.noleft)
-          if (battr !== cell[0] || ch !== cell[1]) {
-            lines[y][xi][0] = battr;
-            lines[y][xi][1] = ch;
-            lines[y].dirty = true;
-          }
+            if (battr !== cell[0] || ch !== cell[1]) {
+              lines[y][xi][0] = battr;
+              lines[y][xi][1] = ch;
+              lines[y].dirty = true;
+            }
         } else {
-          ch = ' ';
+          ch = " ";
           if (dattr !== cell[0] || ch !== cell[1]) {
             lines[y][xi][0] = dattr;
             lines[y][xi][1] = ch;
@@ -2219,19 +2274,19 @@ Element.prototype.render = function() {
       cell = lines[y][xl - 1];
       if (cell) {
         if (this.border.right) {
-          if (this.border.type === 'line') {
-            ch = '\u2502'; // '│'
-          } else if (this.border.type === 'bg') {
+          if (this.border.type === "line") {
+            ch = "\u2502"; // '│'
+          } else if (this.border.type === "bg") {
             ch = this.border.ch;
           }
           if (!coords.noright)
-          if (battr !== cell[0] || ch !== cell[1]) {
-            lines[y][xl - 1][0] = battr;
-            lines[y][xl - 1][1] = ch;
-            lines[y].dirty = true;
-          }
+            if (battr !== cell[0] || ch !== cell[1]) {
+              lines[y][xl - 1][0] = battr;
+              lines[y][xl - 1][1] = ch;
+              lines[y].dirty = true;
+            }
         } else {
-          ch = ' ';
+          ch = " ";
           if (dattr !== cell[0] || ch !== cell[1]) {
             lines[y][xl - 1][0] = dattr;
             lines[y][xl - 1][1] = ch;
@@ -2248,41 +2303,41 @@ Element.prototype.render = function() {
       if (coords.noright && x === xl - 1) continue;
       cell = lines[y][x];
       if (!cell) continue;
-      if (this.border.type === 'line') {
+      if (this.border.type === "line") {
         if (x === xi) {
-          ch = '\u2514'; // '└'
+          ch = "\u2514"; // '└'
           if (!this.border.left) {
             if (this.border.bottom) {
-              ch = '\u2500'; // '─'
+              ch = "\u2500"; // '─'
             } else {
               continue;
             }
           } else {
             if (!this.border.bottom) {
-              ch = '\u2502'; // '│'
+              ch = "\u2502"; // '│'
             }
           }
         } else if (x === xl - 1) {
-          ch = '\u2518'; // '┘'
+          ch = "\u2518"; // '┘'
           if (!this.border.right) {
             if (this.border.bottom) {
-              ch = '\u2500'; // '─'
+              ch = "\u2500"; // '─'
             } else {
               continue;
             }
           } else {
             if (!this.border.bottom) {
-              ch = '\u2502'; // '│'
+              ch = "\u2502"; // '│'
             }
           }
         } else {
-          ch = '\u2500'; // '─'
+          ch = "\u2500"; // '─'
         }
-      } else if (this.border.type === 'bg') {
+      } else if (this.border.type === "bg") {
         ch = this.border.ch;
       }
       if (!this.border.bottom && x !== xi && x !== xl - 1) {
-        ch = ' ';
+        ch = " ";
         if (dattr !== cell[0] || ch !== cell[1]) {
           lines[y][x][0] = dattr;
           lines[y][x][1] = ch;
@@ -2324,7 +2379,7 @@ Element.prototype.render = function() {
     }
   }
 
-  this.children.forEach(function(el) {
+  this.children.forEach(function (el) {
     if (el.screen._ci !== -1) {
       el.index = el.screen._ci++;
     }
@@ -2337,7 +2392,7 @@ Element.prototype.render = function() {
     // }
   });
 
-  this._emit('render', [coords]);
+  this._emit("render", [coords]);
 
   return coords;
 };
@@ -2348,8 +2403,8 @@ Element.prototype._render = Element.prototype.render;
  * Content Methods
  */
 
-Element.prototype.insertLine = function(i, line) {
-  if (typeof line === 'string') line = line.split('\n');
+Element.prototype.insertLine = function (i, line) {
+  if (typeof line === "string") line = line.split("\n");
 
   if (i !== i || i == null) {
     i = this._clines.ftor.length;
@@ -2358,16 +2413,16 @@ Element.prototype.insertLine = function(i, line) {
   i = Math.max(i, 0);
 
   while (this._clines.fake.length < i) {
-    this._clines.fake.push('');
-    this._clines.ftor.push([this._clines.push('') - 1]);
+    this._clines.fake.push("");
+    this._clines.ftor.push([this._clines.push("") - 1]);
     this._clines.rtof(this._clines.fake.length - 1);
   }
 
   // NOTE: Could possibly compare the first and last ftor line numbers to see
   // if they're the same, or if they fit in the visible region entirely.
-  var start = this._clines.length
-    , diff
-    , real;
+  var start = this._clines.length,
+    diff,
+    real;
 
   if (i >= this._clines.ftor.length) {
     real = this._clines.ftor[this._clines.ftor.length - 1];
@@ -2380,7 +2435,7 @@ Element.prototype.insertLine = function(i, line) {
     this._clines.fake.splice(i + j, 0, line[j]);
   }
 
-  this.setContent(this._clines.fake.join('\n'), true);
+  this.setContent(this._clines.fake.join("\n"), true);
 
   diff = this._clines.length - start;
 
@@ -2388,20 +2443,22 @@ Element.prototype.insertLine = function(i, line) {
     var pos = this._getCoords();
     if (!pos) return;
 
-    var height = pos.yl - pos.yi - this.iheight
-      , base = this.childBase || 0
-      , visible = real >= base && real - base < height;
+    var height = pos.yl - pos.yi - this.iheight,
+      base = this.childBase || 0,
+      visible = real >= base && real - base < height;
 
     if (pos && visible && this.screen.cleanSides(this)) {
-      this.screen.insertLine(diff,
+      this.screen.insertLine(
+        diff,
         pos.yi + this.itop + real - base,
         pos.yi,
-        pos.yl - this.ibottom - 1);
+        pos.yl - this.ibottom - 1
+      );
     }
   }
 };
 
-Element.prototype.deleteLine = function(i, n) {
+Element.prototype.deleteLine = function (i, n) {
   n = n || 1;
 
   if (i !== i || i == null) {
@@ -2413,15 +2470,15 @@ Element.prototype.deleteLine = function(i, n) {
 
   // NOTE: Could possibly compare the first and last ftor line numbers to see
   // if they're the same, or if they fit in the visible region entirely.
-  var start = this._clines.length
-    , diff
-    , real = this._clines.ftor[i][0];
+  var start = this._clines.length,
+    diff,
+    real = this._clines.ftor[i][0];
 
   while (n--) {
     this._clines.fake.splice(i, 1);
   }
 
-  this.setContent(this._clines.fake.join('\n'), true);
+  this.setContent(this._clines.fake.join("\n"), true);
 
   diff = start - this._clines.length;
 
@@ -2434,14 +2491,16 @@ Element.prototype.deleteLine = function(i, n) {
 
     height = pos.yl - pos.yi - this.iheight;
 
-    var base = this.childBase || 0
-      , visible = real >= base && real - base < height;
+    var base = this.childBase || 0,
+      visible = real >= base && real - base < height;
 
     if (pos && visible && this.screen.cleanSides(this)) {
-      this.screen.deleteLine(diff,
+      this.screen.deleteLine(
+        diff,
         pos.yi + this.itop + real - base,
         pos.yi,
-        pos.yl - this.ibottom - 1);
+        pos.yl - this.ibottom - 1
+      );
     }
   }
 
@@ -2450,104 +2509,102 @@ Element.prototype.deleteLine = function(i, n) {
   }
 };
 
-Element.prototype.insertTop = function(line) {
+Element.prototype.insertTop = function (line) {
   var fake = this._clines.rtof[this.childBase || 0];
   return this.insertLine(fake, line);
 };
 
-Element.prototype.insertBottom = function(line) {
-  var h = (this.childBase || 0) + this.height - this.iheight
-    , i = Math.min(h, this._clines.length)
-    , fake = this._clines.rtof[i - 1] + 1;
+Element.prototype.insertBottom = function (line) {
+  var h = (this.childBase || 0) + this.height - this.iheight,
+    i = Math.min(h, this._clines.length),
+    fake = this._clines.rtof[i - 1] + 1;
 
   return this.insertLine(fake, line);
 };
 
-Element.prototype.deleteTop = function(n) {
+Element.prototype.deleteTop = function (n) {
   var fake = this._clines.rtof[this.childBase || 0];
   return this.deleteLine(fake, n);
 };
 
-Element.prototype.deleteBottom = function(n) {
-  var h = (this.childBase || 0) + this.height - 1 - this.iheight
-    , i = Math.min(h, this._clines.length - 1)
-    , fake = this._clines.rtof[i];
+Element.prototype.deleteBottom = function (n) {
+  var h = (this.childBase || 0) + this.height - 1 - this.iheight,
+    i = Math.min(h, this._clines.length - 1),
+    fake = this._clines.rtof[i];
 
   n = n || 1;
 
   return this.deleteLine(fake - (n - 1), n);
 };
 
-Element.prototype.setLine = function(i, line) {
+Element.prototype.setLine = function (i, line) {
   i = Math.max(i, 0);
   while (this._clines.fake.length < i) {
-    this._clines.fake.push('');
+    this._clines.fake.push("");
   }
   this._clines.fake[i] = line;
-  return this.setContent(this._clines.fake.join('\n'), true);
+  return this.setContent(this._clines.fake.join("\n"), true);
 };
 
-Element.prototype.setBaseLine = function(i, line) {
+Element.prototype.setBaseLine = function (i, line) {
   var fake = this._clines.rtof[this.childBase || 0];
   return this.setLine(fake + i, line);
 };
 
-Element.prototype.getLine = function(i) {
+Element.prototype.getLine = function (i) {
   i = Math.max(i, 0);
   i = Math.min(i, this._clines.fake.length - 1);
   return this._clines.fake[i];
 };
 
-Element.prototype.getBaseLine = function(i) {
+Element.prototype.getBaseLine = function (i) {
   var fake = this._clines.rtof[this.childBase || 0];
   return this.getLine(fake + i);
 };
 
-Element.prototype.clearLine = function(i) {
+Element.prototype.clearLine = function (i) {
   i = Math.min(i, this._clines.fake.length - 1);
-  return this.setLine(i, '');
+  return this.setLine(i, "");
 };
 
-Element.prototype.clearBaseLine = function(i) {
+Element.prototype.clearBaseLine = function (i) {
   var fake = this._clines.rtof[this.childBase || 0];
   return this.clearLine(fake + i);
 };
 
-Element.prototype.unshiftLine = function(line) {
+Element.prototype.unshiftLine = function (line) {
   return this.insertLine(0, line);
 };
 
-Element.prototype.shiftLine = function(n) {
+Element.prototype.shiftLine = function (n) {
   return this.deleteLine(0, n);
 };
 
-Element.prototype.pushLine = function(line) {
+Element.prototype.pushLine = function (line) {
   if (!this.content) return this.setLine(0, line);
   return this.insertLine(this._clines.fake.length, line);
 };
 
-Element.prototype.popLine = function(n) {
+Element.prototype.popLine = function (n) {
   return this.deleteLine(this._clines.fake.length - 1, n);
 };
 
-Element.prototype.getLines = function() {
+Element.prototype.getLines = function () {
   return this._clines.fake.slice();
 };
 
-Element.prototype.getScreenLines = function() {
+Element.prototype.getScreenLines = function () {
   return this._clines.slice();
 };
 
-Element.prototype.strWidth = function(text) {
-  text = this.parseTags
-    ? helpers.stripTags(text)
-    : text;
+Element.prototype.strWidth = function (text) {
+  text = this.parseTags ? helpers.stripTags(text) : text;
   return this.screen.fullUnicode
     ? unicode.strWidth(text)
     : helpers.dropUnicode(text).length;
 };
 
-Element.prototype.screenshot = function(xi, xl, yi, yl) {
+Element.prototype.screenshot = function (xi, xl, yi, yl) {
   xi = this.lpos.xi + this.ileft + (xi || 0);
   if (xl != null) {
     xl = this.lpos.xi + this.ileft + (xl || 0);

--- a/lib/widgets/textarea.js
+++ b/lib/widgets/textarea.js
@@ -8,12 +8,12 @@
  * Modules
  */
 
-var unicode = require('../unicode');
+var unicode = require("../unicode");
 
 var nextTick = global.setImmediate || process.nextTick.bind(process);
 
-var Node = require('./node');
-var Input = require('./input');
+var Node = require("./node");
+var Input = require("./input");
 
 /**
  * Textarea
@@ -34,32 +34,32 @@ function Textarea(options) {
 
   this.screen._listenKeys(this);
 
-  this.value = options.value || '';
+  this.value = options.value || "";
 
   this.__updateCursor = this._updateCursor.bind(this);
-  this.on('resize', this.__updateCursor);
-  this.on('move', this.__updateCursor);
+  this.on("resize", this.__updateCursor);
+  this.on("move", this.__updateCursor);
 
   if (options.inputOnFocus) {
-    this.on('focus', this.readInput.bind(this, null));
+    this.on("focus", this.readInput.bind(this, null));
   }
 
   if (!options.inputOnFocus && options.keys) {
-    this.on('keypress', function(ch, key) {
+    this.on("keypress", function (ch, key) {
       if (self._reading) return;
-      if (key.name === 'enter' || (options.vi && key.name === 'i')) {
+      if (key.name === "enter" || (options.vi && key.name === "i")) {
         return self.readInput();
       }
-      if (key.name === 'e') {
+      if (key.name === "e") {
         return self.readEditor();
       }
     });
   }
 
   if (options.mouse) {
-    this.on('click', function(data) {
+    this.on("click", function (data) {
       if (self._reading) return;
-      if (data.button !== 'right') return;
+      if (data.button !== "right") return;
       self.readEditor();
     });
   }
@@ -67,33 +67,34 @@ function Textarea(options) {
 
 Textarea.prototype.__proto__ = Input.prototype;
 
-Textarea.prototype.type = 'textarea';
+Textarea.prototype.type = "textarea";
 
-Textarea.prototype._updateCursor = function(get) {
+Textarea.prototype._updateCursor = function (get) {
   if (this.screen.focused !== this) {
     return;
   }
 
-  var lpos = get ? this.lpos : this._getCoords();
+  var lpos = get ? this.lpos : this._getCoords(get);
   if (!lpos) return;
 
-  var last = this._clines[this._clines.length - 1]
-    , program = this.screen.program
-    , line
-    , cx
-    , cy;
+  var last = this._clines[this._clines.length - 1],
+    program = this.screen.program,
+    line,
+    cx,
+    cy;
 
   // Stop a situation where the textarea begins scrolling
   // and the last cline appears to always be empty from the
   // _typeScroll `+ '\n'` thing.
   // Maybe not necessary anymore?
-  if (last === '' && this.value[this.value.length - 1] !== '\n') {
-    last = this._clines[this._clines.length - 2] || '';
+  if (last === "" && this.value[this.value.length - 1] !== "\n") {
+    last = this._clines[this._clines.length - 2] || "";
   }
 
   line = Math.min(
     this._clines.length - 1 - (this.childBase || 0),
-    (lpos.yl - lpos.yi) - this.iheight - 1);
+    lpos.yl - lpos.yi - this.iheight - 1
+  );
 
   // When calling clearValue() on a full textarea with a border, the first
   // argument in the above Math.min call ends up being -2. Make sure we stay
@@ -126,11 +127,11 @@ Textarea.prototype._updateCursor = function(get) {
   }
 };
 
-Textarea.prototype.input =
-Textarea.prototype.setInput =
-Textarea.prototype.readInput = function(callback) {
-  var self = this
-    , focused = this.screen.focused === this;
+Textarea.prototype.input = Textarea.prototype.setInput = Textarea.prototype.readInput = function (
+  callback
+) {
+  var self = this,
+    focused = this.screen.focused === this;
 
   if (this._reading) return;
   this._reading = true;
@@ -144,7 +145,7 @@ Textarea.prototype.readInput = function(callback) {
 
   this.screen.grabKeys = true;
 
-  this._updateCursor();
+  this._updateCursor(true);
   this.screen.program.showCursor();
   //this.screen.program.sgr('normal');
 
@@ -159,10 +160,10 @@ Textarea.prototype.readInput = function(callback) {
     delete self._callback;
     delete self._done;
 
-    self.removeListener('keypress', self.__listener);
+    self.removeListener("keypress", self.__listener);
     delete self.__listener;
 
-    self.removeListener('blur', self.__done);
+    self.removeListener("blur", self.__done);
     delete self.__done;
 
     self.screen.program.hideCursor();
@@ -177,63 +178,64 @@ Textarea.prototype.readInput = function(callback) {
     }
 
     // Ugly
-    if (err === 'stop') return;
+    if (err === "stop") return;
 
     if (err) {
-      self.emit('error', err);
+      self.emit("error", err);
     } else if (value != null) {
-      self.emit('submit', value);
+      self.emit("submit", value);
     } else {
-      self.emit('cancel', value);
+      self.emit("cancel", value);
     }
-    self.emit('action', value);
+    self.emit("action", value);
 
     if (!callback) return;
 
-    return err
-      ? callback(err)
-      : callback(null, value);
+    return err ? callback(err) : callback(null, value);
   };
 
   // Put this in a nextTick so the current
   // key event doesn't trigger any keys input.
-  nextTick(function() {
+  nextTick(function () {
     self.__listener = self._listener.bind(self);
-    self.on('keypress', self.__listener);
+    self.on("keypress", self.__listener);
   });
 
   this.__done = this._done.bind(this, null, null);
-  this.on('blur', this.__done);
+  this.on("blur", this.__done);
 };
 
-Textarea.prototype._listener = function(ch, key) {
-  var done = this._done
-    , value = this.value;
+Textarea.prototype._listener = function (ch, key) {
+  var done = this._done,
+    value = this.value;
 
-  if (key.name === 'return') return;
-  if (key.name === 'enter') {
-    ch = '\n';
+  if (key.name === "return") return;
+  if (key.name === "enter") {
+    ch = "\n";
   }
 
   // TODO: Handle directional keys.
-  if (key.name === 'left' || key.name === 'right'
-      || key.name === 'up' || key.name === 'down') {
-    ;
+  if (
+    key.name === "left" ||
+    key.name === "right" ||
+    key.name === "up" ||
+    key.name === "down"
+  ) {
   }
 
-  if (this.options.keys && key.ctrl && key.name === 'e') {
+  if (this.options.keys && key.ctrl && key.name === "e") {
     return this.readEditor();
   }
 
   // TODO: Optimize typing by writing directly
   // to the screen and screen buffer here.
-  if (key.name === 'escape') {
+  if (key.name === "escape") {
     done(null, null);
-  } else if (key.name === 'backspace') {
+  } else if (key.name === "backspace") {
     if (this.value.length) {
       if (this.screen.fullUnicode) {
         if (unicode.isSurrogate(this.value, this.value.length - 2)) {
-        // || unicode.isCombining(this.value, this.value.length - 1)) {
+          // || unicode.isCombining(this.value, this.value.length - 1)) {
           this.value = this.value.slice(0, -2);
         } else {
           this.value = this.value.slice(0, -1);
@@ -253,7 +255,7 @@ Textarea.prototype._listener = function(ch, key) {
   }
 };
 
-Textarea.prototype._typeScroll = function() {
+Textarea.prototype._typeScroll = function () {
   // XXX Workaround
   var height = this.height - this.iheight;
   if (this._clines.length - this.childBase > height) {
@@ -261,11 +263,11 @@ Textarea.prototype._typeScroll = function() {
   }
 };
 
-Textarea.prototype.getValue = function() {
+Textarea.prototype.getValue = function () {
   return this.value;
 };
 
-Textarea.prototype.setValue = function(value) {
+Textarea.prototype.setValue = function (value) {
   if (value == null) {
     value = this.value;
   }
@@ -278,50 +280,49 @@ Textarea.prototype.setValue = function(value) {
   }
 };
 
-Textarea.prototype.clearInput =
-Textarea.prototype.clearValue = function() {
-  return this.setValue('');
+Textarea.prototype.clearInput = Textarea.prototype.clearValue = function () {
+  return this.setValue("");
 };
 
-Textarea.prototype.submit = function() {
+Textarea.prototype.submit = function () {
   if (!this.__listener) return;
-  return this.__listener('\x1b', { name: 'escape' });
+  return this.__listener("\x1b", { name: "escape" });
 };
 
-Textarea.prototype.cancel = function() {
+Textarea.prototype.cancel = function () {
   if (!this.__listener) return;
-  return this.__listener('\x1b', { name: 'escape' });
+  return this.__listener("\x1b", { name: "escape" });
 };
 
-Textarea.prototype.render = function() {
+Textarea.prototype.render = function () {
   this.setValue();
   return this._render();
 };
 
-Textarea.prototype.editor =
-Textarea.prototype.setEditor =
-Textarea.prototype.readEditor = function(callback) {
+Textarea.prototype.editor = Textarea.prototype.setEditor = Textarea.prototype.readEditor = function (
+  callback
+) {
   var self = this;
 
   if (this._reading) {
-    var _cb = this._callback
-      , cb = callback;
+    var _cb = this._callback,
+      cb = callback;
 
-    this._done('stop');
+    this._done("stop");
 
-    callback = function(err, value) {
+    callback = function (err, value) {
       if (_cb) _cb(err, value);
       if (cb) cb(err, value);
     };
   }
 
   if (!callback) {
-    callback = function() {};
+    callback = function () {};
   }
 
-  return this.screen.readEditor({ value: this.value }, function(err, value) {
+  return this.screen.readEditor({ value: this.value }, function (err, value) {
     if (err) {
-      if (err.message === 'Unsuccessful.') {
+      if (err.message === "Unsuccessful.") {
         self.screen.render();
         return self.readInput(callback);
       }

--- a/package.json
+++ b/package.json
@@ -1,21 +1,37 @@
 {
-  "name": "blessed",
-  "description": "A high-level terminal interface library for node.js.",
-  "author": "Christopher Jeffrey",
-  "version": "0.1.81",
+  "name": "@hp4k1h5/blessed",
+  "description": "a fork of Christopher Jeffrey's blessed",
+  "author": "hp4k1h5",
+  "version": "0.0.2",
   "license": "MIT",
   "main": "./lib/blessed.js",
   "bin": "./bin/tput.js",
   "preferGlobal": false,
-  "repository": "git://github.com/chjj/blessed.git",
-  "homepage": "https://github.com/chjj/blessed",
-  "bugs": { "url": "http://github.com/chjj/blessed/issues" },
-  "keywords": ["curses", "tui", "tput", "terminfo", "termcap"],
-  "tags": ["curses", "tui", "tput", "terminfo", "termcap"],
+  "repository": "git://github.com/hp4k1h5/blessed.git",
+  "homepage": "https://github.com/hp4k1h5/blessed",
+  "bugs": {
+    "url": "http://github.com/hp4k1h5/blessed/issues"
+  },
+  "keywords": [
+    "curses",
+    "tui",
+    "tput",
+    "terminfo",
+    "termcap"
+  ],
+  "tags": [
+    "curses",
+    "tui",
+    "tput",
+    "terminfo",
+    "termcap"
+  ],
   "engines": {
     "node": ">= 0.8.0"
   },
   "browserify": {
-    "transform": ["./browser/transform.js"]
+    "transform": [
+      "./browser/transform.js"
+    ]
   }
 }


### PR DESCRIPTION
if a carousel page has an input field, `.focus()` will crash the app. in my tests, calling `getCoords(true)` from widgets/textarea prevents an undefined this.screen from crashing the app. parameter `get` should be true when called from textarea.

