### PR TITLE
Remove duplicate property from simple-form example

### DIFF
--- a/example/simple-form.js
+++ b/example/simple-form.js
@@ -47,7 +47,6 @@ var cancel = blessed.button({
   },
   left: 20,
   top: 2,
-  shrink: true,
   name: 'cancel',
   content: 'cancel',
   style: {

--- a/example/simple-form.js
+++ b/example/simple-form.js
@@ -23,7 +23,6 @@ var submit = blessed.button({
   },
   left: 10,
   top: 2,
-  shrink: true,
   name: 'submit',
   content: 'submit',
   style: {


### PR DESCRIPTION
Caught by TS1117: An object literal cannot have multiple properties with the same name.