### PR TITLE
fix null attr access

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -2540,7 +2540,10 @@ Program.prototype._attr = function(param, val) {
       , out = [];
 
     parts.forEach(function(part) {
-      part = self._attr(part, val).slice(2, -1);
+      var arrt = self._attr(part, val);
+      if (!attr) return;
+
+      part = attr.slice(2, -1);
       if (part === '') return;
       if (used[part]) return;
       used[part] = true;

--- a/lib/program.js
+++ b/lib/program.js
@@ -2540,7 +2540,7 @@ Program.prototype._attr = function(param, val) {
       , out = [];
 
     parts.forEach(function(part) {
-      var arrt = self._attr(part, val);
+      var attr = self._attr(part, val);
       if (!attr) return;
 
       part = attr.slice(2, -1);


### PR DESCRIPTION
I'm using [blessed](https://github.com/chjj/blessed) as part of PM2 setup
Noticed that PM2 monit command works for some apps but not for other, after checking the issue. It was this error
```
TypeError: Cannot read properties of null (reading 'slice')
    at /Users/ahmed/.nvm/versions/node/v18.16.0/lib/node_modules/pm2/node_modules/blessed/lib/program.js:2543:35
    at Array.forEach (<anonymous>)
    at Program._attr (/Users/ahmed/.nvm/versions/node/v18.16.0/lib/node_modules/pm2/node_modules/blessed/lib/program.js:2542:11)
    at Element._parseTags (/Users/ahmed/.nvm/versions/node/v18.16.0/lib/node_modules/pm2/node_modules/blessed/lib/widgets/element.js:498:26)
    at Element.parseContent (/Users/ahmed/.nvm/versions/node/v18.16.0/lib/node_modules/pm2/node_modules/blessed/lib/widgets/element.js:393:22)
    at Box.<anonymous> (/Users/ahmed/.nvm/versions/node/v18.16.0/lib/node_modules/pm2/node_modules/blessed/lib/widgets/element.js:184:10)
    at EventEmitter._emit (/Users/ahmed/.nvm/versions/node/v18.16.0/lib/node_modules/pm2/node_modules/blessed/lib/events.js:94:20)
    at EventEmitter.emit (/Users/ahmed/.nvm/versions/node/v18.16.0/lib/node_modules/pm2/node_modules/blessed/lib/events.js:117:12)
    at emit (/Users/ahmed/.nvm/versions/node/v18.16.0/lib/node_modules/pm2/node_modules/blessed/lib/widgets/node.js:109:15)
    at Node.insert (/Users/ahmed/.nvm/versions/node/v18.16.0/lib/node_modules/pm2/node_modules/blessed/lib/widgets/node.js:111:5)
```

This PR should fix this noisy issue