### PR TITLE
Program.prototype._attr should ignore null/undefined parameters.

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -2540,7 +2540,9 @@ Program.prototype._attr = function(param, val) {
       , out = [];
 
     parts.forEach(function(part) {
-      part = self._attr(part, val).slice(2, -1);
+      var attr = self._attr(part, val);
+      if (attr == null) return;
+      part = attr.slice(2, -1);
       if (part === '') return;
       if (used[part]) return;
       used[part] = true;


### PR DESCRIPTION
Handle undefined and null in `Program.prototype._attr`.

This will probably resolve https://github.com/Unitech/pm2/issues/5577