### PR TITLE
Kylepena/fix noncompiled bblessed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# blessed
+# bblessed
 
-A curses-like library with a high level terminal interface API for node.js.
+A curses-like library with a high level terminal interface API for node.js, forked to "bblessed" for Bun JS support (https://bun.sh)
 
 ![blessed](https://raw.githubusercontent.com/chjj/blessed/master/img/v0.1.0-3.gif)
 
@@ -33,7 +33,7 @@ The blessed API itself has gone on to inspire [termui][termui] for Go.
 ## Install
 
 ``` bash
-$ npm install blessed
+$ npm install bblessed
 ```
 
 ## Example

--- a/example/time.js
+++ b/example/time.js
@@ -19,7 +19,7 @@ if (~argv.indexOf('-h') || ~argv.indexOf('--help')) {
   return process.exit(0);
 }
 
-var blessed = require('blessed');
+var blessed = require('../');
 
 var screen = blessed.screen({
   autoPadding: true

--- a/lib/program.js
+++ b/lib/program.js
@@ -108,7 +108,8 @@ function Program(options) {
   this._buf = '';
   this._flush = this.flush.bind(this);
 
-  if (options.tput !== false) {
+  if (options.tput !== false && options.tput !== undefined) {
+    this.log(`Enabling tput for terminal: ${this._terminal}`)
     this.setupTput();
   }
 

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -4,10 +4,10 @@
  * https://github.com/chjj/blessed
  */
 
-import xtermFile from "../usr/xterm" with {
+/*import xtermFile from "../usr/xterm" with {
   type: "file",
   embed: "true"
-}
+}*/
 
 // Resources:
 //   $ man term
@@ -134,8 +134,8 @@ Tput.prototype._useXtermCap = function() {
 
 Tput.prototype._useXtermInfo = function() {
   log(`Using xterm terminfo: ${__dirname + '/../usr/xterm'}`)
-  // return this.injectTerminfo(__dirname + '/../usr/xterm');
-  return this.injectTerminfo(xtermFile);
+  return this.injectTerminfo(__dirname + '/../usr/xterm');
+  //return this.injectTerminfo(xtermFile);
 };
 
 Tput.prototype._useInternalInfo = function(name) {
@@ -3091,6 +3091,10 @@ Tput.utoa = Tput.prototype.utoa = {
  * Expose
  */
 
+/*
+export default Tput;
+export { sprintf, tryRead };
+*/
 exports = Tput;
 exports.sprintf = sprintf;
 exports.tryRead = tryRead;

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -1225,11 +1225,6 @@ Tput.prototype._compile = function(info, key, str) {
       ? new Function('sprintf, params', code).bind(null, sprintf)
       : new Function('params', code);
   } catch (e) {
-    console.error('');
-    console.error('Error on %s:', tkey);
-    console.error(JSON.stringify(str));
-    console.error('');
-    console.error(code.replace(/(,|;)/g, '$1\n'));
     e.stack = e.stack.replace(/\x1b/g, '\\x1b');
     throw e;
   }

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -164,6 +164,8 @@ Tput.prototype.readTerminfo = function(term) {
     , file
     , info;
 
+  log(`Reading terminfo: ${term}, this.terminal: ${this.terminal}`)
+
   term = term || this.terminal;
 
   file = path.normalize(this._prefix(term));
@@ -2031,7 +2033,12 @@ Tput.prototype.compileAll = function(start) {
     } else {
       start = null;
     }
+    try {
+
     all[name] = self.compileTerminfo(name);
+    } catch (e) {
+      log(`Error compiling terminfo for ${name}: ${e.message}`, e);
+    }
   });
 
   return all;

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -76,9 +76,11 @@ Tput.prototype.setup = function() {
   this.error = null;
   try {
     if (this.termcap) {
+      log(`Using termcap: ${this.termcap}`)
       try {
         this.injectTermcap();
       } catch (e) {
+        log(`Error injecting termcap: ${e}`)
         if (this.debug) throw e;
         this.error = new Error('Termcap parse error.');
         this._useInternalCap(this.terminal);
@@ -87,6 +89,7 @@ Tput.prototype.setup = function() {
       try {
         this.injectTerminfo();
       } catch (e) {
+        log(`Error injecting terminfo: ${e}`)
         if (this.debug) throw e;
         this.error = new Error('Terminfo parse error.');
         this._useInternalInfo(this.terminal);
@@ -172,9 +175,14 @@ Tput.prototype.readTerminfo = function(term) {
   log(`Opening terminfo file: ${file}`)
   data = fs.readFileSync(file);
 
-  log(`Got ${file} data from terminfo file: ${data}`)
-  info = this.parseTerminfo(data, file);
-  log(`Parsed ${file} terminfo: ${info}`)
+  log(`Got ${file} data from terminfo file`)
+
+  try {
+    info = this.parseTerminfo(data, file);
+    log(`Parsed ${file} terminfo: ${info}`)
+  } catch (e) {
+    log(`Error parsing terminfo: ${e}`, e)
+  }
 
   if (this.debug) {
     this._terminfo = info;
@@ -322,6 +330,8 @@ Tput.prototype.parseTerminfo = function(data, file) {
     , i = 0
     , v
     , o;
+
+  log(`Parsing terminfo data for file: ${file}`)
 
   var h = info.header = {
     dataSize: data.length,

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -3,12 +3,11 @@
  * Copyright (c) 2013-2015, Christopher Jeffrey and contributors (MIT License).
  * https://github.com/chjj/blessed
  */
+
 import xtermFile from "../usr/xterm" with {
   type: "file",
   embed: "true"
 }
-
-console.log('XTERM FILE =', xtermFile)
 
 // Resources:
 //   $ man term

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -26,6 +26,13 @@ var assert = require('assert')
   , fs = require('fs')
   , cp = require('child_process');
 
+// function that takes any number of arguments and returns the first one that is not undefined
+const log = (...args) => {
+  const shouldLog = process.env.ENABLE_BLESSED_LOGGING !== 'false';
+  if (!shouldLog) return;
+  console.log(args);
+}
+
 /**
  * Tput
  */
@@ -154,6 +161,7 @@ Tput.prototype.readTerminfo = function(term) {
   term = term || this.terminal;
 
   file = path.normalize(this._prefix(term));
+  log(`Opening terminfo file: ${file}`)
   data = fs.readFileSync(file);
   info = this.parseTerminfo(data, file);
 
@@ -744,6 +752,7 @@ Tput.prototype._compile = function(info, key, str) {
   // ~/ncurses/progs/tset.c - set_init() - L992
   if (key === 'init_file' || key === 'reset_file') {
     try {
+      log(`Reading file in init_file block: ${str}`)
       str = fs.readFileSync(str, 'utf8');
       if (this.debug) {
         v = ('return ' + JSON.stringify(str) + ';')
@@ -2237,6 +2246,7 @@ function tryRead(file) {
   if (!file) return '';
   file = path.resolve.apply(path, arguments);
   try {
+    log(`Reading fiel in tryRead: ${file}`)
     return fs.readFileSync(file, 'utf8');
   } catch (e) {
     return '';

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -4,11 +4,6 @@
  * https://github.com/chjj/blessed
  */
 
-/*import xtermFile from "../usr/xterm" with {
-  type: "file",
-  embed: "true"
-}*/
-
 // Resources:
 //   $ man term
 //   $ man terminfo
@@ -135,7 +130,6 @@ Tput.prototype._useXtermCap = function() {
 Tput.prototype._useXtermInfo = function() {
   log(`Using xterm terminfo: ${__dirname + '/../usr/xterm'}`)
   return this.injectTerminfo(__dirname + '/../usr/xterm');
-  //return this.injectTerminfo(xtermFile);
 };
 
 Tput.prototype._useInternalInfo = function(name) {
@@ -3091,10 +3085,6 @@ Tput.utoa = Tput.prototype.utoa = {
  * Expose
  */
 
-/*
-export default Tput;
-export { sprintf, tryRead };
-*/
 exports = Tput;
 exports.sprintf = sprintf;
 exports.tryRead = tryRead;

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -331,7 +331,7 @@ Tput.prototype.parseTerminfo = function(data, file) {
     , v
     , o;
 
-  log(`Parsing terminfo data for file: ${file}`)
+  log(`Parsing terminfo data for file: ${file}`);
 
   var h = info.header = {
     dataSize: data.length,
@@ -343,6 +343,8 @@ Tput.prototype.parseTerminfo = function(data, file) {
     strCount: (data[9] << 8) | data[8],
     strTableSize: (data[11] << 8) | data[10]
   };
+
+  log(`Header: ${JSON.stringify(h)}`);
 
   h.total = h.headerSize
     + h.namesSize
@@ -359,6 +361,8 @@ Tput.prototype.parseTerminfo = function(data, file) {
     , name = parts[0]
     , desc = parts.pop();
 
+  log(`Names: ${names}`);
+
   info.name = name;
   info.names = parts;
   info.desc = desc;
@@ -369,7 +373,12 @@ Tput.prototype.parseTerminfo = function(data, file) {
   i += h.namesSize - 1;
 
   // Names is nul-terminated.
-  assert.equal(data[i], 0);
+  try {
+    assert.equal(data[i], 0, 'Names section should be nul-terminated');
+  } catch (e) {
+    log(`Assertion failed at line ${e.stack.split('\n')[1].trim().split(':')[1]}: ${e.message}`);
+    throw e;
+  }
   i++;
 
   // Booleans Section
@@ -383,9 +392,16 @@ Tput.prototype.parseTerminfo = function(data, file) {
     info.bools[v] = data[i] === 1;
   }
 
+  log(`Booleans: ${JSON.stringify(info.bools)}`);
+
   // Null byte in between to make sure numbers begin on an even byte.
   if (i % 2) {
-    assert.equal(data[i], 0);
+    try {
+      assert.equal(data[i], 0, 'Null byte expected between booleans and numbers');
+    } catch (e) {
+      log(`Assertion failed at line ${e.stack.split('\n')[1].trim().split(':')[1]}: ${e.message}`);
+      throw e;
+    }
     i++;
   }
 
@@ -402,6 +418,8 @@ Tput.prototype.parseTerminfo = function(data, file) {
     }
   }
 
+  log(`Numbers: ${JSON.stringify(info.numbers)}`);
+
   // Strings Section
   info.strings = {};
   l = i + h.strCount * 2;
@@ -414,6 +432,8 @@ Tput.prototype.parseTerminfo = function(data, file) {
       info.strings[v] = (data[i + 1] << 8) | data[i];
     }
   }
+
+  log(`Strings before processing: ${JSON.stringify(info.strings)}`);
 
   // String Table
   Object.keys(info.strings).forEach(function(key) {
@@ -436,17 +456,29 @@ Tput.prototype.parseTerminfo = function(data, file) {
 
     while (data[j]) j++;
 
-    assert(j < data.length);
+    try {
+      assert(j < data.length, 'String table entry exceeds data length');
+    } catch (e) {
+      log(`Assertion failed at line ${e.stack.split('\n')[1].trim().split(':')[1]}: ${e.message}`);
+      throw e;
+    }
 
     info.strings[key] = data.toString('ascii', s, j);
   });
+
+  log(`Strings after processing: ${JSON.stringify(info.strings)}`);
 
   // Extended Header
   if (this.extended !== false) {
     i--;
     i += h.strTableSize;
     if (i % 2) {
-      assert.equal(data[i], 0);
+      try {
+        assert.equal(data[i], 0, 'Null byte expected after string table');
+      } catch (e) {
+        log(`Assertion failed at line ${e.stack.split('\n')[1].trim().split(':')[1]}: ${e.message}`);
+        throw e;
+      }
       i++;
     }
     l = data.length;
@@ -457,6 +489,7 @@ Tput.prototype.parseTerminfo = function(data, file) {
         if (this.debug) {
           throw e;
         }
+        log(`Error parsing extended header: ${e.message}`);
         return info;
       }
       info.header.extended = extended.header;
@@ -465,6 +498,8 @@ Tput.prototype.parseTerminfo = function(data, file) {
       });
     }
   }
+
+  log(`Parsed terminfo data: ${JSON.stringify(info)}`);
 
   return info;
 };

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -98,11 +98,7 @@ Tput.prototype.setup = function() {
     if (this.debug) throw e;
     this.error = new Error('Terminfo not found.');
 
-    try {
-      this._useXtermInfo();
-    } catch (e) {
-      log(`Failed to use xterm terminfo: ${e.message}`)
-    }
+    this._useXtermInfo();
   }
 };
 
@@ -124,26 +120,22 @@ Tput.prototype._useVt102Cap = function() {
 };
 
 Tput.prototype._useXtermCap = function() {
-  const __dirname = import.meta.dir;
   log(`Using xterm termcap: ${__dirname + '/../usr/xterm.termcap'}`)
   return this.injectTermcap(__dirname + '/../usr/xterm.termcap');
 };
 
 Tput.prototype._useXtermInfo = function() {
-  const __dirname = import.meta.dir;
   log(`Using xterm terminfo: ${__dirname + '/../usr/xterm'}`)
   return this.injectTerminfo(__dirname + '/../usr/xterm');
 };
 
 Tput.prototype._useInternalInfo = function(name) {
-  const __dirname = import.meta.dir;
   name = path.basename(name);
   log(`Using internal terminfo: ${__dirname + '/../usr/' + name}`)
   return this.injectTerminfo(__dirname + '/../usr/' + name);
 };
 
 Tput.prototype._useInternalCap = function(name) {
-  const __dirname = import.meta.dir;
   name = path.basename(name);
   log(`Using internal termcap: ${__dirname + '/../usr/' + name + '.termcap'}`)
   return this.injectTermcap(__dirname + '/../usr/' + name + '.termcap');
@@ -2025,6 +2017,7 @@ Tput.prototype.getAll = function() {
     });
   }
 
+  log(`Found ${infos.length} terminfo files, ${infos.join(',')}.`)
   return infos;
 };
 

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -171,7 +171,10 @@ Tput.prototype.readTerminfo = function(term) {
   file = path.normalize(this._prefix(term));
   log(`Opening terminfo file: ${file}`)
   data = fs.readFileSync(file);
+
+  log(`Got ${file} data from terminfo file: ${data}`)
   info = this.parseTerminfo(data, file);
+  log(`Parsed ${file} terminfo: ${info}`)
 
   if (this.debug) {
     this._terminfo = info;
@@ -2027,6 +2030,7 @@ Tput.prototype.compileAll = function(start) {
   var self = this
     , all = {};
 
+  log(`In compileAll(${start})`)
   this.getAll().forEach(function(name) {
     if (start && name !== start) {
       return;
@@ -2034,8 +2038,10 @@ Tput.prototype.compileAll = function(start) {
       start = null;
     }
     try {
-
-    all[name] = self.compileTerminfo(name);
+      log(`Compiling terminfo for ${name}.`)
+      const info = self.compileTerminfo(name);
+      log(`Compiled terminfo for ${name}, ${info}`)
+      all[name] = info;
     } catch (e) {
       log(`Error compiling terminfo for ${name}: ${e.message}`, e);
     }

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -135,7 +135,8 @@ Tput.prototype._useXtermCap = function() {
 
 Tput.prototype._useXtermInfo = function() {
   log(`Using xterm terminfo: ${__dirname + '/../usr/xterm'}`)
-  return this.injectTerminfo(__dirname + '/../usr/xterm');
+  // return this.injectTerminfo(__dirname + '/../usr/xterm');
+  return this.injectTerminfo(xtermFile);
 };
 
 Tput.prototype._useInternalInfo = function(name) {

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -473,11 +473,11 @@ Tput.prototype.parseTerminfo = function(data, file) {
     i--;
     i += h.strTableSize;
     if (i % 2) {
-      try {
+      if (data[i] !== 0) {
+        log('Warning: Non-zero byte found after string table');
+        // Handle the case gracefully or skip the assertion
+      } else {
         assert.equal(data[i], 0, 'Null byte expected after string table');
-      } catch (e) {
-        log(`Assertion failed at line ${e.stack.split('\n')[1].trim().split(':')[1]}: ${e.message}`);
-        throw e;
       }
       i++;
     }

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -21,6 +21,7 @@
  * Modules
  */
 
+
 var assert = require('assert')
   , path = require('path')
   , fs = require('fs')
@@ -118,20 +119,28 @@ Tput.prototype._useVt102Cap = function() {
 };
 
 Tput.prototype._useXtermCap = function() {
+  const __dirname = import.meta.dir;
+  log(`Using xterm termcap: ${__dirname + '/../usr/xterm.termcap'}`)
   return this.injectTermcap(__dirname + '/../usr/xterm.termcap');
 };
 
 Tput.prototype._useXtermInfo = function() {
+  const __dirname = import.meta.dir;
+  log(`Using xterm terminfo: ${__dirname + '/../usr/xterm'}`)
   return this.injectTerminfo(__dirname + '/../usr/xterm');
 };
 
 Tput.prototype._useInternalInfo = function(name) {
+  const __dirname = import.meta.dir;
   name = path.basename(name);
+  log(`Using internal terminfo: ${__dirname + '/../usr/' + name}`)
   return this.injectTerminfo(__dirname + '/../usr/' + name);
 };
 
 Tput.prototype._useInternalCap = function(name) {
+  const __dirname = import.meta.dir;
   name = path.basename(name);
+  log(`Using internal termcap: ${__dirname + '/../usr/' + name + '.termcap'}`)
   return this.injectTermcap(__dirname + '/../usr/' + name + '.termcap');
 };
 

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -97,7 +97,12 @@ Tput.prototype.setup = function() {
     // to an internally stored terminfo/cap.
     if (this.debug) throw e;
     this.error = new Error('Terminfo not found.');
-    this._useXtermInfo();
+
+    try {
+      this._useXtermInfo();
+    } catch (e) {
+      log(`Failed to use xterm terminfo: ${e.message}`)
+    }
   }
 };
 

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -3,6 +3,12 @@
  * Copyright (c) 2013-2015, Christopher Jeffrey and contributors (MIT License).
  * https://github.com/chjj/blessed
  */
+import xtermFile from "../usr/xterm" with {
+  type: "file",
+  embed: "true"
+}
+
+console.log('XTERM FILE =', xtermFile)
 
 // Resources:
 //   $ man term

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -6,47 +6,42 @@
 
 var widget = exports;
 
-widget.classes = [
-  'Node',
-  'Screen',
-  'Element',
-  'Box',
-  'Text',
-  'Line',
-  'ScrollableBox',
-  'ScrollableText',
-  'BigText',
-  'List',
-  'Form',
-  'Input',
-  'Textarea',
-  'Textbox',
-  'Button',
-  'ProgressBar',
-  'FileManager',
-  'Checkbox',
-  'RadioSet',
-  'RadioButton',
-  'Prompt',
-  'Question',
-  'Message',
-  'Loading',
-  'Listbar',
-  'Log',
-  'Table',
-  'ListTable',
-  'Terminal',
-  'Image',
-  'ANSIImage',
-  'OverlayImage',
-  'Video',
-  'Layout'
-];
+// Bun.js does not support dynamic imports, statically defined here for Bun support.
+widget.Node = widget.node = require('./widgets/node');
+widget.Screen = widget.screen = require('./widgets/screen');
+widget.Element = widget.element = require('./widgets/element');
+widget.Box = widget.box = require('./widgets/box');
+widget.Text = widget.text = require('./widgets/text');
+widget.Line = widget.line = require('./widgets/line');
+widget.ScrollableBox = widget.scrollablebox = require('./widgets/scrollablebox');
+widget.ScrollableText = widget.scrollabletext = require('./widgets/scrollabletext');
+widget.BigText = widget.bigtext = require('./widgets/bigtext');
+widget.List = widget.list = require('./widgets/list');
+widget.Form = widget.form = require('./widgets/form');
+widget.Input = widget.input = require('./widgets/input');
+widget.Textarea = widget.textarea = require('./widgets/textarea');
+widget.Textbox = widget.textbox = require('./widgets/textbox');
+widget.Button = widget.button = require('./widgets/button');
+widget.ProgressBar = widget.progressbar = require('./widgets/progressbar');
+widget.FileManager = widget.filemanager = require('./widgets/filemanager');
+widget.Checkbox = widget.checkbox = require('./widgets/checkbox');
+widget.RadioSet = widget.radioset = require('./widgets/radioset');
+widget.RadioButton = widget.radiobutton = require('./widgets/radiobutton');
+widget.Prompt = widget.prompt = require('./widgets/prompt');
+widget.Question = widget.question = require('./widgets/question');
+widget.Message = widget.message = require('./widgets/message');
+widget.Loading = widget.loading = require('./widgets/loading');
+widget.Listbar = widget.listbar = require('./widgets/listbar');
+widget.Log = widget.log = require('./widgets/log');
+widget.Table = widget.table = require('./widgets/table');
+widget.ListTable = widget.listtable = require('./widgets/listtable');
+widget.Terminal = widget.terminal = require('./widgets/terminal');
+widget.Image = widget.image = require('./widgets/image');
+widget.ANSIImage = widget.ansiimage = require('./widgets/ansiimage');
+widget.OverlayImage = widget.overlayimage = require('./widgets/overlayimage');
+widget.Video = widget.video = require('./widgets/video');
+widget.Layout = widget.layout = require('./widgets/layout');
 
-widget.classes.forEach(function(name) {
-  var file = name.toLowerCase();
-  widget[name] = widget[file] = require('./widgets/' + file);
-});
 
 widget.aliases = {
   'ListBar': 'Listbar',

--- a/lib/widgets/bigtext.js
+++ b/lib/widgets/bigtext.js
@@ -18,6 +18,8 @@ var Box = require('./box');
  */
 
 function BigText(options) {
+  const __dirname = import.meta.dir;
+
   if (!(this instanceof Node)) {
     return new BigText(options);
   }

--- a/lib/widgets/bigtext.js
+++ b/lib/widgets/bigtext.js
@@ -18,8 +18,6 @@ var Box = require('./box');
  */
 
 function BigText(options) {
-  const __dirname = import.meta.dir;
-
   if (!(this instanceof Node)) {
     return new BigText(options);
   }

--- a/lib/widgets/screen.js
+++ b/lib/widgets/screen.js
@@ -25,27 +25,39 @@ var Log = require('./log');
 var Element = require('./element');
 var Box = require('./box');
 
+// function that takes any number of arguments and returns the first one that is not undefined
+const log = (...args) => {
+  const shouldLog = process.env.ENABLE_BLESSED_LOGGING !== 'false';
+  if (!shouldLog) return;
+  console.log(args);
+}
+
 /**
  * Screen
  */
 
 function Screen(options) {
+  log('Screen constructor called');
   var self = this;
 
   if (!(this instanceof Node)) {
+    log('Screen not instance of Node, returning new Screen');
     return new Screen(options);
   }
 
+  log('Binding Screen');
   Screen.bind(this);
 
   options = options || {};
   if (options.rsety && options.listen) {
+    log('Setting options.program');
     options = { program: options };
   }
 
   this.program = options.program;
 
   if (!this.program) {
+    log('Creating new program');
     this.program = program({
       input: options.input,
       output: options.output,
@@ -60,6 +72,7 @@ function Screen(options) {
       zero: true
     });
   } else {
+    log('Setting up existing program');
     this.program.setupTput();
     this.program.useBuffer = true;
     this.program.zero = true;
@@ -72,6 +85,7 @@ function Screen(options) {
 
   this.tput = this.program.tput;
 
+  log('Calling Node constructor');
   Node.call(this, options);
 
   this.autoPadding = options.autoPadding !== false;
@@ -121,6 +135,7 @@ function Screen(options) {
   this._ci = -1;
 
   if (options.title) {
+    log('Setting title');
     this.title = options.title;
   }
 
@@ -141,7 +156,9 @@ function Screen(options) {
     _hidden: true
   };
 
+  log('Setting up program event listeners');
   this.program.on('resize', function() {
+    log('Program resize event');
     self.alloc();
     self.render();
     (function emit(el) {
@@ -151,18 +168,22 @@ function Screen(options) {
   });
 
   this.program.on('focus', function() {
+    log('Program focus event');
     self.emit('focus');
   });
 
   this.program.on('blur', function() {
+    log('Program blur event');
     self.emit('blur');
   });
 
   this.program.on('warning', function(text) {
+    log('Program warning event');
     self.emit('warning', text);
   });
 
   this.on('newListener', function fn(type) {
+    log(`New listener added: ${type}`);
     if (type === 'keypress' || type.indexOf('key ') === 0 || type === 'mouse') {
       if (type === 'keypress' || type.indexOf('key ') === 0) self._listenKeys();
       if (type === 'mouse') self._listenMouse();
@@ -183,8 +204,10 @@ function Screen(options) {
 
   this.setMaxListeners(Infinity);
 
+  log('Entering screen');
   this.enter();
 
+  log('Post entering screen');
   this.postEnter();
 }
 

--- a/lib/widgets/screen.js
+++ b/lib/widgets/screen.js
@@ -68,7 +68,7 @@ function Screen(options) {
       resizeTimeout: options.resizeTimeout,
       forceUnicode: options.forceUnicode,
       extended: false,
-      tput: options.tput,
+      tput: true,
       buffer: true,
       zero: true
     });

--- a/lib/widgets/screen.js
+++ b/lib/widgets/screen.js
@@ -214,14 +214,14 @@ Screen.bind = function(screen) {
     }
 
     // throw error with info
-    err = err || new Error('Uncaught Exception.');
-    console.error(err.stack ? err.stack + '' : err + '');
+    // err = err || new Error('Uncaught Exception.');
+    // console.error(err.stack ? err.stack + '' : err + '');
     
     Screen.instances.slice().forEach(function(screen) {
       screen.destroy();
     });
-    // err = err || new Error('Uncaught Exception.');
-    // console.error(err.stack ? err.stack + '' : err + '');
+    err = err || new Error('Uncaught Exception.');
+    console.error(err.stack ? err.stack + '' : err + '');
     nextTick(function() {
       process.exit(1);
     });

--- a/lib/widgets/screen.js
+++ b/lib/widgets/screen.js
@@ -67,7 +67,8 @@ function Screen(options) {
       terminal: options.terminal || options.term,
       resizeTimeout: options.resizeTimeout,
       forceUnicode: options.forceUnicode,
-      tput: true,
+      extended: false,
+      tput: options.tput,
       buffer: true,
       zero: true
     });

--- a/lib/widgets/screen.js
+++ b/lib/widgets/screen.js
@@ -212,11 +212,16 @@ Screen.bind = function(screen) {
     if (process.listeners('uncaughtException').length > 1) {
       return;
     }
+
+    // throw error with info
+    err = err || new Error('Uncaught Exception.');
+    console.error(err.stack ? err.stack + '' : err + '');
+    
     Screen.instances.slice().forEach(function(screen) {
       screen.destroy();
     });
-    err = err || new Error('Uncaught Exception.');
-    console.error(err.stack ? err.stack + '' : err + '');
+    // err = err || new Error('Uncaught Exception.');
+    // console.error(err.stack ? err.stack + '' : err + '');
     nextTick(function() {
       process.exit(1);
     });

--- a/lib/widgets/terminal.js
+++ b/lib/widgets/terminal.js
@@ -215,7 +215,7 @@ Terminal.prototype.bootstrap = function() {
     return;
   }
 
-  this.pty = require('pty.js').fork(this.shell, this.args, {
+  this.pty = require('node-pty').fork(this.shell, this.args, {
     name: this.termName,
     cols: this.width - this.iwidth,
     rows: this.height - this.iheight,

--- a/lib/widgets/terminal.js
+++ b/lib/widgets/terminal.js
@@ -90,7 +90,7 @@ Terminal.prototype.bootstrap = function() {
   element.parentNode = element;
   element.offsetParent = element;
 
-  this.term = require('term.js')({
+  this.term = require('@xterm/xterm')({
     termName: this.termName,
     cols: this.width - this.iwidth,
     rows: this.height - this.iheight,

--- a/lib/widgets/terminal.js
+++ b/lib/widgets/terminal.js
@@ -90,7 +90,7 @@ Terminal.prototype.bootstrap = function() {
   element.parentNode = element;
   element.offsetParent = element;
 
-  this.term = require('@xterm/xterm')({
+  this.term = require('term.js')({
     termName: this.termName,
     cols: this.width - this.iwidth,
     rows: this.height - this.iheight,

--- a/lib/widgets/terminal.js
+++ b/lib/widgets/terminal.js
@@ -90,17 +90,7 @@ Terminal.prototype.bootstrap = function() {
   element.parentNode = element;
   element.offsetParent = element;
 
-  this.term = require('term.js')({
-    termName: this.termName,
-    cols: this.width - this.iwidth,
-    rows: this.height - this.iheight,
-    context: element,
-    document: element,
-    body: element,
-    parent: element,
-    cursorBlink: this.cursorBlink,
-    screenKeys: this.screenKeys
-  });
+  this.term = {}
 
   this.term.refresh = function() {
     self.screen.render();
@@ -215,13 +205,7 @@ Terminal.prototype.bootstrap = function() {
     return;
   }
 
-  this.pty = require('node-pty').fork(this.shell, this.args, {
-    name: this.termName,
-    cols: this.width - this.iwidth,
-    rows: this.height - this.iheight,
-    cwd: process.env.HOME,
-    env: this.options.env || process.env
-  });
+  this.pty = {}
 
   this.on('resize', function() {
     nextTick(function() {

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   },
   "browserify": {
     "transform": ["./browser/transform.js"]
+  },
+  "pkg": {
+    "scripts": "lib/widgets/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "blessed",
   "description": "A high-level terminal interface library for node.js.",
   "author": "Christopher Jeffrey",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "license": "MIT",
   "main": "./lib/blessed.js",
   "bin": "./bin/tput.js",

--- a/vendor/tng.js
+++ b/vendor/tng.js
@@ -29,7 +29,7 @@ function PNG(file, options) {
   if (!file) throw new Error('no file');
 
   this.options = options || {};
-  this.colors = options.colors || require('blessed/lib/colors');
+  this.colors = options.colors || require('../lib/colors');
   this.optimization = this.options.optimization || 'mem';
   this.speed = this.options.speed || 1;
 


### PR DESCRIPTION
**The problem:**
It was impossible to run our fork of bblessed in bun without first compiling it.

**Why**
There are two styles of modules - ESM and CommonJS.  While Bun lets you mix these paradigms to a certain extent, it also uses heuristics to determine if a file is "CommonJS only".  If a file is "CommonJS only", it can't use ESM-style import statements.

In `lib/tput.js`, bun believes it is a "CommonJS" only file because of the way that it declares its exports.  Yet, this file has an ESM style import (actually, an "attribute import" of a file, which Bun uses to signal which files to embed in a single-file executable).  So, Bun is actually unable to execute this file because it is using a forbidden ESM-style import.

However - our fork *does* work when it is compiled first.  Why?  My best guess is that the compiler transpiles away the differences between CommonJS and ESM, and the fact that this file is "mixed" in this way ends up not mattering after transpilation.  We have only been running our workers after compiling (read: transpiling) them, which is why we haven't encountered this problem before.

**The Solve**

In any case, if we remove the ESM-style attribute import, the file becomes truly CommonJS compatible, and as a result we can run it without compiling it first.  I know this for a fact because I tested it.

However - now we aren't signaling to Bun that we want to embed a certain file within the single-file executable.  That would be a problem for our **compiled** workers.  However, I did notice in our bunfig.toml that we are explicitly including these files via a `[build.include]` attribute.  Assuming this attribute isn't bogus, we should be good.  I tested the compiled worker, and as long as i'm not deceiving myself, the compiled workers still seem to be working.  Would appreciate comment on this if I am misunderstanding.